### PR TITLE
fix: remove author img halo

### DIFF
--- a/blocks/article-header/article-header.css
+++ b/blocks/article-header/article-header.css
@@ -100,7 +100,6 @@ main .article-byline {
 main .article-byline .article-author-image,
 main .article-byline .article-author-image img {
   margin: 0;
-  background: #fa0f00;
   margin-right: 16px;
   height: 64px;
   width: 64px;

--- a/blocks/article-header/article-header.js
+++ b/blocks/article-header/article-header.js
@@ -15,6 +15,7 @@ async function populateAuthorImg(imgContainer, url, name) {
       const src = new URL(placeholderImg.getAttribute('src'), new URL(url));
       const picture = createOptimizedPicture(src, name, false, [{ width: 200 }]);
       imgContainer.append(picture);
+      imgContainer.style.backgroundImage = 'none';
       picture.querySelector('img').onerror = (e) => {
         // removing 404 img will reveal fallback background img
         e.srcElement.remove();


### PR DESCRIPTION
## Description

remove red halo around author images

## Related Issue

#15 

## Screenshots and Links

**before**: 
<img width="220" alt="Screen Shot 2021-10-19 at 12 02 17 PM" src="https://user-images.githubusercontent.com/43383503/137965717-21d3ca5c-49ef-4999-b352-481f364d9f58.png">
https://main--blog--adobe.hlx3.page/en/publish/2021/10/13/need-to-reach-friends-family-or-colleagues-try-email

**after**:
<img width="213" alt="Screen Shot 2021-10-19 at 12 02 31 PM" src="https://user-images.githubusercontent.com/43383503/137965751-09eb3615-35bc-45e5-a8e1-18a42566b095.png">
https://author-img--blog--adobe.hlx3.page/en/publish/2021/10/13/need-to-reach-friends-family-or-colleagues-try-email

