### PR TITLE
fix: check if load event already occured

### DIFF
--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -200,7 +200,7 @@ const intersectHandler = (entries) => {
 };
 
 export default function decorate(block) {
-  window.addEventListener('load', () => {
+  const run = () => {
     const options = {
       root: null,
       rootMargin: '0px',
@@ -209,5 +209,11 @@ export default function decorate(block) {
 
     const observer = new IntersectionObserver(intersectHandler, options);
     observer.observe(block);
-  });
+  };
+
+  if (document.readyState === 'complete') {
+    run();
+  } else {
+    window.addEventListener('load', run);
+  }
 }


### PR DESCRIPTION
Fix #21 

You probably will not see a difference here: https://embeds-not-loaded--blog--adobe.hlx3.page/en/publish/2021/09/15/adobe-for-all-do-one-thing-today

But locally, it makes a difference!