### PR TITLE
fix(images): js error if side-by-side

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -548,15 +548,18 @@ function getImageCaption(picture) {
  */
 function buildImageBlocks(mainEl) {
   // select all non-featured, default (non-images block) images
+  const parentEls = [];
   const imgEls = [...mainEl.querySelectorAll(':scope > div > p > picture')];
   imgEls.forEach((imgEl) => {
     const parentEl = imgEl.parentNode;
     const imagesBlockEl = buildBlock('images', {
-      elems: [parentEl.cloneNode(true), getImageCaption(imgEl)],
+      elems: [imgEl.cloneNode(true), getImageCaption(imgEl)],
     });
     parentEl.parentNode.insertBefore(imagesBlockEl, parentEl);
-    parentEl.remove();
+    parentEls.push(parentEl);
   });
+  // remove old parent elems
+  parentEls.forEach((parentEl) => parentEl.remove());
 }
 
 /**


### PR DESCRIPTION
Fix #56 

The problem was that we removed the parent elements too eagerly.
- Before: https://main--blog--adobe.hlx3.page/en/publish/2021/04/22/photoshop-and-adobe-experience-manager-accelerating-creativity-through-apis
- After: https://issue-56--blog--adobe.hlx3.page/en/publish/2021/04/22/photoshop-and-adobe-experience-manager-accelerating-creativity-through-apis