### PR TITLE
feat(images): auto side-by-side images block

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -548,18 +548,21 @@ function getImageCaption(picture) {
  */
 function buildImageBlocks(mainEl) {
   // select all non-featured, default (non-images block) images
-  const parentEls = [];
   const imgEls = [...mainEl.querySelectorAll(':scope > div > p > picture')];
+  let lastImagesBlock;
   imgEls.forEach((imgEl) => {
     const parentEl = imgEl.parentNode;
     const imagesBlockEl = buildBlock('images', {
       elems: [imgEl.cloneNode(true), getImageCaption(imgEl)],
     });
-    parentEl.parentNode.insertBefore(imagesBlockEl, parentEl);
-    parentEls.push(parentEl);
+    if (parentEl.parentNode) {
+      parentEl.replaceWith(imagesBlockEl);
+      lastImagesBlock = imagesBlockEl;
+    } else {
+      // same parent, add image to last images block
+      lastImagesBlock.firstChild.append(imagesBlockEl.firstChild.firstChild);
+    }
   });
-  // remove old parent elems
-  parentEls.forEach((parentEl) => parentEl.remove());
 }
 
 /**


### PR DESCRIPTION
Fix #56 

The test page has both a real images block with 2 images in it, and 2 imagesnext to eachother in the default content.

Before:
- https://main--blog--adobe.hlx3.page/en/drafts/rofe/test
- https://issue-56--blog--adobe.hlx3.page/en/drafts/rofe/test