### PR TITLE
feat: chunked index

### DIFF
--- a/blocks/article-feed/article-feed.js
+++ b/blocks/article-feed/article-feed.js
@@ -5,6 +5,7 @@ import {
   fetchPlaceholders,
   getArticleTaxonomy,
   getTaxonomy,
+  stamp,
 } from '../../scripts/scripts.js';
 
 function isCardOnPage(article) {
@@ -268,9 +269,7 @@ function buildFilter(type, tax, ph, block, config) {
   return container;
 }
 
-async function filterArticles(config, offset) {
-  const index = await fetchBlogArticleIndex();
-
+async function filterArticles(config, feed, limit, offset) {
   const result = [];
 
   /* filter posts by category, tag and author */
@@ -284,56 +283,51 @@ async function filterArticles(config, offset) {
     }
   });
 
-  /* filter and ignore if already in result */
-  const size = 12;
-  let end = offset;
-  const articles = [];
-  while (articles.length < size && end < index.data.length) {
-    const article = index.data[end];
-    const matchedAll = Object.keys(filters).every((key) => {
-      if (key === 'exclude' || key === 'tags' || key === 'topics') {
-        const tax = getArticleTaxonomy(article);
-        const matchedFilter = filters[key].some((val) => (tax.allTopics
-          && tax.allTopics.map((t) => t.toLowerCase()).includes(val)));
-        return key === 'exclude' ? !matchedFilter : matchedFilter;
-      }
-      if (key === 'selectedProducts' || key === 'selectedIndustries') {
-        const tax = getArticleTaxonomy(article);
-        if (filters.selectedProducts && filters.selectedIndustries) {
-          // match product && industry
-          const matchProduct = filters.selectedProducts.some((val) => (tax.allTopics
+  while ((feed.data.length < limit + offset) && (!feed.complete)) {
+    const beforeLoading = new Date();
+    // eslint-disable-next-line no-await-in-loop
+    const index = await fetchBlogArticleIndex();
+    const indexChunk = index.data.slice(feed.cursor);
+
+    const beforeFiltering = new Date();
+    /* filter and ignore if already in result */
+    const feedChunk = indexChunk.filter((article) => {
+      const matchedAll = Object.keys(filters).every((key) => {
+        if (key === 'exclude' || key === 'tags' || key === 'topics') {
+          const tax = getArticleTaxonomy(article);
+          const matchedFilter = filters[key].some((val) => (tax.allTopics
             && tax.allTopics.map((t) => t.toLowerCase()).includes(val)));
-          const matchIndustry = filters.selectedIndustries.some((val) => (tax.allTopics
-            && tax.allTopics.map((t) => t.toLowerCase()).includes(val)));
-          return matchProduct && matchIndustry;
+          return key === 'exclude' ? !matchedFilter : matchedFilter;
         }
-        const matchedFilter = filters[key].some((val) => (tax.allTopics
-          && tax.allTopics.map((t) => t.toLowerCase()).includes(val)));
+        if (key === 'selectedProducts' || key === 'selectedIndustries') {
+          const tax = getArticleTaxonomy(article);
+          if (filters.selectedProducts && filters.selectedIndustries) {
+            // match product && industry
+            const matchProduct = filters.selectedProducts.some((val) => (tax.allTopics
+              && tax.allTopics.map((t) => t.toLowerCase()).includes(val)));
+            const matchIndustry = filters.selectedIndustries.some((val) => (tax.allTopics
+              && tax.allTopics.map((t) => t.toLowerCase()).includes(val)));
+            return matchProduct && matchIndustry;
+          }
+          const matchedFilter = filters[key].some((val) => (tax.allTopics
+            && tax.allTopics.map((t) => t.toLowerCase()).includes(val)));
+          return matchedFilter;
+        }
+        const matchedFilter = filters[key].some((val) => (article[key]
+          && article[key].toLowerCase().includes(val)));
         return matchedFilter;
-      }
-      const matchedFilter = filters[key].some((val) => (article[key]
-        && article[key].toLowerCase().includes(val)));
-      return matchedFilter;
+      });
+      return (matchedAll && !result.includes(article) && !isCardOnPage(article));
     });
-
-    if (matchedAll && !result.includes(article) && !isCardOnPage(article)) {
-      articles.push(article);
-    }
-    end += 1;
+    stamp(`chunk measurements - loading: ${beforeFiltering - beforeLoading}ms filtering: ${new Date() - beforeFiltering}ms`);
+    feed.cursor = index.data.length;
+    feed.complete = index.complete;
+    feed.data = [...feed.data, ...feedChunk];
   }
-  const page = {
-    articles,
-    size,
-    end,
-    totalArticles: index.data.length,
-  };
-
-  return page;
 }
 
-async function decorateArticleFeed(articleFeedEl, config, offset = 0) {
-  const page = await filterArticles(config, offset);
-
+async function decorateArticleFeed(articleFeedEl, config, offset = 0,
+  feed = { data: [], complete: false, cursor: 0 }) {
   let articleCards = articleFeedEl.querySelector('.article-cards');
   if (!articleCards) {
     articleCards = document.createElement('div');
@@ -341,12 +335,18 @@ async function decorateArticleFeed(articleFeedEl, config, offset = 0) {
     articleFeedEl.appendChild(articleCards);
   }
 
-  page.articles.forEach((article) => {
+  const limit = 12;
+  const pageEnd = offset + limit;
+  await filterArticles(config, feed, limit, offset);
+  const articles = feed.data;
+  const max = pageEnd > articles.length ? articles.length : pageEnd;
+  for (let i = offset; i < max; i += 1) {
+    const article = articles[i];
     const card = buildArticleCard(article);
     articleCards.append(card);
-  });
+  }
 
-  if (page.totalArticles > page.end) {
+  if (articles.length > pageEnd || !feed.complete) {
     const loadMore = document.createElement('a');
     loadMore.className = 'load-more button small primary light';
     loadMore.href = '#';
@@ -356,7 +356,7 @@ async function decorateArticleFeed(articleFeedEl, config, offset = 0) {
     loadMore.addEventListener('click', (event) => {
       event.preventDefault();
       loadMore.remove();
-      decorateArticleFeed(articleFeedEl, config, page.end);
+      decorateArticleFeed(articleFeedEl, config, pageEnd, feed);
     });
   }
   articleFeedEl.classList.add('appear');

--- a/blocks/gnav/gnav-search.js
+++ b/blocks/gnav/gnav-search.js
@@ -59,9 +59,7 @@ async function populateSearchResults(searchTerms, resultsContainer) {
   resultsContainer.innerHTML = '';
 
   if (terms.length) {
-    if (!window.blogIndex) {
-      window.blogIndex = await fetchBlogArticleIndex();
-    }
+    await fetchBlogArticleIndex();
 
     const articles = window.blogIndex.data;
 

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -10,10 +10,98 @@
  * governing permissions and limitations under the License.
  */
 
-/* globals webVitals */
-import { loadScript, sampleRUM, getHelixEnv } from './scripts.js';
+/* globals webVitals digitalData _satellite */
+/* eslint-disable no-underscore-dangle */
 
-const { target } = getHelixEnv();
+import {
+  loadScript,
+  sampleRUM,
+  getHelixEnv,
+  getMetadata,
+  getTaxonomy,
+  getLanguage,
+} from './scripts.js';
+
+function getTags() {
+  return getMetadata('article:tag', true);
+}
+
+function checkDX(tag) {
+  const dxtags = [
+    'Experience Cloud', 'Experience Manager', 'Magento Commerce', 'Marketo Engage', 'Target', 'Commerce Cloud', 'Campaign', 'Audience Manager, Analytics, Advertising Cloud',
+    'Travel & Hospitality', 'Media & Entertainment', 'Financial Services', 'Government', 'Non-profits', 'Other', 'Healthcare', 'High Tech', 'Retail', 'Telecom', 'Manufacturing', 'Education',
+    'B2B', 'Social', 'Personalization', 'Campaign Management', 'Content Management', 'Email Marketing', 'Commerce', 'Analytics', 'Advertising', 'Digital Transformation',
+  ];
+  return dxtags.includes(tag);
+}
+
+function setDigitalData() {
+  // creates a string from the categories & products for analytics
+  // example: "Category: #AdobeForAll | Category: Adobe Life | Product: Photoshop"
+  const getPageFilterInfo = () => {
+    let pageFilterInfo = '';
+    const tags = getTags();
+    const taxonomy = getTaxonomy();
+    const categories = [];
+    const products = [];
+    tags.forEach((t) => {
+      const tax = taxonomy.get(t);
+      if (tax) {
+        if (tax.category.toLowerCase() === taxonomy.PRODUCTS) {
+          products.push(t);
+        } else {
+          categories.push(t);
+        }
+      }
+    });
+
+    pageFilterInfo += `Category: ${categories.join(' | ')}`;
+    pageFilterInfo += ` | Product: ${products.join(' | ')}`;
+
+    return pageFilterInfo;
+  };
+
+  const langMap = { en: 'en-US' };
+  let lang = getLanguage();
+  if (langMap[lang]) lang = langMap[lang];
+  digitalData._set('page.pageInfo.language', lang);
+  digitalData._set('page.pageInfo.siteSection', 'blog.adobe.com');
+  digitalData._set('page.pageInfo.attributes.pageFilterInfo', getPageFilterInfo());
+}
+
+/**
+ * tracks the initial page load
+ */
+function trackPageLoad() {
+  if (!digitalData || !_satellite) {
+    return;
+  }
+
+  // pageload for initial pageload (For regular tracking of pageload hits)
+  _satellite.track('pageload', {
+    digitalData: digitalData._snapshot(),
+  });
+}
+
+const { target, name } = getHelixEnv();
+
+let isDX = false;
+const tags = getTags();
+tags.forEach((tag) => {
+  if (checkDX(tag)) {
+    isDX = true;
+  }
+});
+
+let accounts = '';
+if (isDX) {
+  if (name === 'prod') {
+    accounts = 'adbadobedxprod';
+  } else if (name === 'stage') {
+    accounts = 'adbadobedxqa';
+  }
+}
+
 window.marketingtech = window.marketingtech || {};
 window.marketingtech.adobe = {
   target,
@@ -22,11 +110,18 @@ window.marketingtech.adobe = {
     property: 'global',
     environment: 'production',
   },
+  analytics: {
+    // additional report suites to send data to “,” separated  Ex: 'RS1,RS2'
+    additionalAccounts: accounts,
+  },
 };
 window.targetGlobalSettings = window.targetGlobalSettings || {};
 window.targetGlobalSettings.bodyHidingEnabled = false;
 
-const launchScriptEl = loadScript('https://www.adobe.com/marketingtech/main.no-promise.min.js');
+const launchScriptEl = loadScript('https://www.adobe.com/marketingtech/main.no-promise.min.js', () => {
+  setDigitalData();
+  trackPageLoad();
+});
 launchScriptEl.setAttribute('data-seed-adobelaunch', 'true');
 
 /* Core Web Vitals RUM collection */

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -546,18 +546,21 @@ function getImageCaption(picture) {
  */
 function buildImageBlocks(mainEl) {
   // select all non-featured, default (non-images block) images
-  const parentEls = [];
   const imgEls = [...mainEl.querySelectorAll(':scope > div > p > picture')];
+  let lastImagesBlock;
   imgEls.forEach((imgEl) => {
     const parentEl = imgEl.parentNode;
     const imagesBlockEl = buildBlock('images', {
       elems: [imgEl.cloneNode(true), getImageCaption(imgEl)],
     });
-    parentEl.parentNode.insertBefore(imagesBlockEl, parentEl);
-    parentEls.push(parentEl);
+    if (parentEl.parentNode) {
+      parentEl.replaceWith(imagesBlockEl);
+      lastImagesBlock = imagesBlockEl;
+    } else {
+      // same parent, add image to last images block
+      lastImagesBlock.firstChild.append(imagesBlockEl.firstChild.firstChild);
+    }
   });
-  // remove old parent elems
-  parentEls.forEach((parentEl) => parentEl.remove());
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1026,16 +1026,26 @@ export function addFavIcon(href) {
  * fetches blog article index.
  * @returns {object} index with data and path lookup
  */
-let queryIndex;
-
 export async function fetchBlogArticleIndex() {
-  if (queryIndex) {
-    return queryIndex;
-  }
-  const resp = await fetch(`${getRootPath()}/query-index.json`);
+  const pageSize = 500;
+  window.blogIndex = window.blogIndex || {
+    data: [],
+    byPath: {},
+    offset: 0,
+    complete: false,
+  };
+  if (window.blogIndex.complete) return (window.blogIndex);
+  const index = window.blogIndex;
+  const resp = await fetch(`${getRootPath()}/query-index.json?limit=${pageSize}&offset=${index.offset}`);
   const json = await resp.json();
-  queryIndex = { data: json.data };
-  return queryIndex;
+  const complete = (json.limit + json.offset) === json.total;
+  json.data.forEach((post) => {
+    index.data.push(post);
+    index.byPath[post.path.split('.')[0]] = post;
+  });
+  index.complete = complete;
+  index.offset = json.offset + pageSize;
+  return (index);
 }
 
 /**
@@ -1228,7 +1238,7 @@ displayEnv();
  * (needs a refactor)
  */
 
-function stamp(message) {
+export function stamp(message) {
   if (window.name.includes('performance')) {
     debug(`${new Date() - performance.timing.navigationStart}:${message}`);
   }


### PR DESCRIPTION
fix:
https://github.com/adobe/blog/issues/38

initial support for chunked index... 

compare:
https://chunked-index--blog--adobe.hlx.live/
https://chunked-index--blog--adobe.hlx.live/en/topics/creativity
vs. 
https://main--blog--adobe.hlx.live/
https://main--blog--adobe.hlx.live/en/topics/creativity

with chunk size set at `500` i am getting the following on throttled
```
throttled: chunk measurements - loading: 2437ms filtering: 39ms
unthrottled: chunk measurements - loading: 147ms filtering: 14ms
```
having said that, the inner loop for the filtering is considerably more expensive, which is definitely a problem especially with respect to the blocking time over 50ms. as in the current index architecture this loop has to run through up to 13k items, i think we should consider optimizing the inner most loop to be faster. 

i wasn't able to find a topic page or an author page to make sure that the filtering actually works, so if @kptdobe could point me somewhere i am happy to take a look.