### PR TITLE
fix: css selectors must be stronger than main style ones

### DIFF
--- a/blocks/recommended-articles/recommended-articles.css
+++ b/blocks/recommended-articles/recommended-articles.css
@@ -1,17 +1,17 @@
-main .recommended-articles-container,
-main .recommended-articles-small-container {
+main .section-wrapper.recommended-articles-container,
+main .section-wrapper.recommended-articles-small-container {
   visibility: unset;
   background: var(--color-gray-200);
   padding-bottom: 1rem;
 }
 
-main .recommended-articles-container > div {
+main .section-wrapper.recommended-articles-container > div {
   max-width: 100%;
   text-align: center;
   padding-top: 16px;
 }
 
-main .recommended-articles {
+main .recommended-articles-container .recommended-articles {
   visibility: unset;
   min-height: unset;
 }


### PR DESCRIPTION
Depending on how the page is loading, `styles.css` may come after `recommended-articles` and take over. Articles are then not visible.

Test pages:
- https://main--blog--adobe.hlx3.page/en/drafts/jennie/breaking-into-the-professional-creative-industry
- https://fix-invisible-recommended-article--blog--adobe.hlx3.page/en/drafts/jennie/breaking-into-the-professional-creative-industry

Other pages still work as before https://fix-invisible-recommended-article--blog--adobe.hlx3.page/en/publish/2021/10/26/new-creative-cloud-releases-enable-creative-collaboration-drive-innovation-empower-creative-careers