### PR TITLE
fix: gnav config and locale

### DIFF
--- a/blocks/gnav/gnav.js
+++ b/blocks/gnav/gnav.js
@@ -3,6 +3,7 @@ import {
   getHelixEnv,
   debug,
   adjustLinks,
+  getLocale,
 } from '../../scripts/scripts.js';
 import createTag from './gnav-utils.js';
 
@@ -220,9 +221,9 @@ class Gnav {
     const profileEl = createTag('div', { class: 'gnav-profile' });
 
     window.adobeid = {
-      client_id: 'bizweb',
+      client_id: 'theblog-helix',
       scope: 'AdobeID,openid,gnav',
-      locale: 'en_US',
+      locale: getLocale(),
       autoValidateToken: true,
       environment: this.env.ims,
       useLocalStorage: false,

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -112,6 +112,17 @@ const LANG = {
   BR: 'br',
 };
 
+const LANG_LOCALE = {
+  en: 'en_US',
+  de: 'de_DE',
+  fr: 'fr_FR',
+  ko: 'ko_KR',
+  es: 'es_ES',
+  it: 'it_IT',
+  jp: 'ja_JP',
+  br: 'pt_BR',
+};
+
 let language;
 
 export function getLanguage() {
@@ -128,6 +139,11 @@ export function getLanguage() {
     }
   }
   return language;
+}
+
+export function getLocale() {
+  const lang = getLanguage();
+  return LANG_LOCALE[lang];
 }
 
 function getDateLocale() {


### PR DESCRIPTION
Client id is wrong and locale was hardcoded to `en_US`.

I have tested all the locales, they take me to the corresponding login page on adobe.com.

Test: https://fix-gnav-setup--blog--adobe.hlx3.page/