### PR TITLE
fix: replace '-' with '/'

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -968,6 +968,7 @@ export function formatLocalCardDate(date) {
     // - add one more day for Excel's leap year bug
     jsDate = new Date(Math.round((date - (1 + 25567 + 1)) * 86400 * 1000));
   } else {
+    // Safari won't accept '-' as a date separator
     jsDate = date.replace(/-/g, '/');
   }
   const dateLocale = getDateLocale();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -968,7 +968,7 @@ export function formatLocalCardDate(date) {
     // - add one more day for Excel's leap year bug
     jsDate = new Date(Math.round((date - (1 + 25567 + 1)) * 86400 * 1000));
   } else {
-    jsDate = date.replace('-', '/');
+    jsDate = date.replace(/-/g, '/');
   }
   const dateLocale = getDateLocale();
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -967,6 +967,8 @@ export function formatLocalCardDate(date) {
     // - add days between 1/1/1900 and 1/1/1970
     // - add one more day for Excel's leap year bug
     jsDate = new Date(Math.round((date - (1 + 25567 + 1)) * 86400 * 1000));
+  } else {
+    jsDate = date.replace('-', '/');
   }
   const dateLocale = getDateLocale();
 


### PR DESCRIPTION
fix #105 

Works for both Chrome and Safari: https://fix-invalid-date--blog--adobe.hlx3.page