### PR TITLE
Enable feed update plugin in Sidekick Extension

### DIFF
--- a/blocks/article-feed/article-feed.js
+++ b/blocks/article-feed/article-feed.js
@@ -271,7 +271,7 @@ function buildFilter(type, tax, ph, block, config) {
   return container;
 }
 
-async function filterArticles(config, feed, limit, offset) {
+export async function filterArticles(config, feed, limit, offset) {
   const result = [];
 
   /* filter posts by category, tag and author */
@@ -415,6 +415,7 @@ async function decorateFeedFilter(articleFeedEl, config) {
 
 export default function decorate(block) {
   const config = readBlockConfig(block);
+  block.dataset.config = JSON.stringify(config);
   block.innerHTML = '';
   if (config.filters) {
     decorateFeedFilter(block, config);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1237,6 +1237,10 @@ function loadDelayed() {
  * Decorates the page.
  */
 async function decoratePage() {
+  // only decorate page once
+  if (document.body.classList.contains('appear')) {
+    return;
+  }
   await loadEager();
   loadLazy();
   loadDelayed();

--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -183,7 +183,7 @@ const fetchFilteredArticles = async (limit = 50) => {
     complete: false,
   };
   await filterArticles(config, feed, limit, 0);
-  return feed.data.slice(0, limit);
+  return feed.data.length ? feed.data.slice(0, limit) : null;
 };
 
 const hasFeed = () => !!document.querySelector('link[type="application/xml+atom"]');

--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -41,7 +41,7 @@ const toggleCardPreview = async (sk) => {
     const {
       getBlogArticle,
       buildArticleCard,
-    } = await import(`${window.location.origin}/scripts/scripts.js`);
+    } = await import('/scripts/scripts.js');
     $modal.append(buildArticleCard(await getBlogArticle(sk.location.pathname)));
 
     const $overlay = document.createElement('div');
@@ -58,7 +58,7 @@ const toggleCardPreview = async (sk) => {
 const predictUrl = async (host, path) => {
   const {
     getBlogArticle,
-  } = await import(`${window.location.origin}/scripts/scripts.js`);
+  } = await import('/scripts/scripts.js');
   const pathsplits = path.split('/');
   let publishPath = '';
   const article = await getBlogArticle(path);
@@ -75,7 +75,7 @@ const predictUrl = async (host, path) => {
 const copyArticleData = async (sk) => {
   const {
     getBlogArticle,
-  } = await import(`${window.location.origin}/scripts/scripts.js`);
+  } = await import('/scripts/scripts.js');
   const { location, status } = sk;
   const {
     date,
@@ -173,11 +173,11 @@ const updateFeed = async (sk) => {
   if (feedUrl) {
     const {
       fetchBlogArticleIndex,
-    } = await import(`${window.location.origin}/scripts/scripts.js`);
+    } = await import('/scripts/scripts.js');
     const {
       connect,
       saveFile,
-    } = await import(`${window.location.origin}/tools/sidekick/sharepoint.js`);
+    } = await import('/tools/sidekick/sharepoint.js');
     const { owner, repo, ref } = sk.config;
     const feedPath = new URL(feedUrl).pathname;
     console.log(`Updating feed ${feedPath}`);

--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -185,7 +185,7 @@ const updateFeed = async (sk) => {
       try {
         sk.showModal('Please wait …', true);
         const { data } = await fetchBlogArticleIndex();
-        const feedXml = generateFeed('Adobe Blog', 'Adobe', data);
+        const feedXml = generateFeed(document.title, 'Adobe', data);
         await saveFile(feedXml, feedPath);
         let resp = await fetch(`https://admin.hlx3.page/preview/${owner}/${repo}/${ref}${feedPath}`, { method: 'POST' });
         if (!resp.ok) {


### PR DESCRIPTION
Due to the way the sidekick is loaded in the extension (imported into the JS "sandbox"), combined with the fact that the sidekick is now a custom element with shadow DOM, it can't access global properties on the outer `window` (`window` is the shadow DOM's root). This means, the update feed plugin will have to import functions from the project modules and re-compute the blog index.

This introduced the following changes to the project code:
- export `filterArticles()`
- store block config in data attribute of block element
- make sure `decoratePage()` is only executed once, otherwise it wreaks havoc on the DOM

https://sk-ext-feed--blog--adobe.hlx3.page/