### PR TITLE
Remove duplicate 'description' key from helix-query

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -36,10 +36,6 @@ indices:
         select: head > meta[property="article:tag"]
         values: |
           attribute(el, 'content')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
       robots:
         select: head > meta[name="robots"]
         value: |


### PR DESCRIPTION
## Description

Removed duplicate 'description' key in index properties.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![image](https://user-images.githubusercontent.com/5942270/141830594-dc592033-8e28-4ac2-91e2-95cd40a7d165.png)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).

