### PR TITLE
fix: email support in social + language specific text

### DIFF
--- a/blocks/social-links/social-links.css
+++ b/blocks/social-links/social-links.css
@@ -3,16 +3,45 @@ main .social-links {
   margin: 0 auto 30px 0;
 }
 
+main p.social-links-text {
+  margin: 8px 0;
+  font-weight: var(--detail-font-weight);
+  color: var(--detail-color);
+  font-size: var(--detail-font-size-s);
+  line-height: var(--detail-line-height);
+  text-transform: uppercase;
+  letter-spacing: .1em;
+}
+
+@media (min-width: 600px) {
+  main .social-links div div {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  main p.social-links-text {
+    margin-right: 1.5rem;
+  }
+
+  main .social-links .social-email {
+    font-size: var(--body-font-size-m);
+  }
+}
+
 main .social-links ul {
   padding-inline-start: 0;
+  margin: 0;
 }
 
 main .social-links li {
   list-style: none;
   display: inline;
-  margin-right: 16px;
   position: relative;
   top: 2px;
+}
+
+main .social-links li:not(:last-of-type) {
+  margin-right: 16px;
 }
 
 main .social-links svg {
@@ -29,6 +58,5 @@ main .social-links svg:hover {
 @media (min-width: 600px) {
   main .social-links {
     text-align: left;
-    padding-left: 232px;
   }
 }

--- a/blocks/social-links/social-links.css
+++ b/blocks/social-links/social-links.css
@@ -63,5 +63,6 @@ main .social-links svg:hover {
 @media (min-width: 600px) {
   main .social-links {
     text-align: left;
+    padding-left: calc(200px + 2rem);
   }
 }

--- a/blocks/social-links/social-links.css
+++ b/blocks/social-links/social-links.css
@@ -1,6 +1,11 @@
 main .social-links {
+  visibility: hidden;
   text-align: center;
   margin: 0 auto 30px 0;
+}
+
+main .social-links[data-block-loaded=true] {
+  visibility: unset;
 }
 
 main p.social-links-text {

--- a/blocks/social-links/social-links.js
+++ b/blocks/social-links/social-links.js
@@ -1,3 +1,7 @@
+import {
+  fetchPlaceholders,
+} from '../../scripts/scripts.js';
+
 /**
  * Creates an SVG tag using the specified ID.
  * @param {string} id The ID
@@ -29,6 +33,9 @@ function getSocialLinkDetails(url) {
       title = t;
     }
   });
+  if (!title && url.includes('@')) {
+    title = 'Email';
+  }
   if (!title) title = 'Unknown';
   const type = title.toLowerCase();
   return {
@@ -42,7 +49,7 @@ function getSocialLinkDetails(url) {
  * Decorates social links.
  * @param {Element} blockEl The block element
  */
-export default function decorateSocialLinks(blockEl) {
+export default async function decorateSocialLinks(blockEl) {
   blockEl.querySelectorAll(':scope a').forEach((linkEl) => {
     const { title, type, className } = getSocialLinkDetails(linkEl.href);
     if (type === 'unknown') {
@@ -50,9 +57,25 @@ export default function decorateSocialLinks(blockEl) {
       linkEl.remove();
       return;
     }
+    if (type === 'email') {
+      linkEl.setAttribute('title', title);
+      linkEl.href = `mailto:${linkEl.textContent}`;
+      linkEl.className = className;
+      return;
+    }
     linkEl.innerHTML = '';
     linkEl.appendChild(createSVG(type));
     linkEl.setAttribute('title', title);
     linkEl.className = className;
   });
+  const ul = blockEl.querySelector('ul');
+  if (ul.hasChildNodes()) {
+    // add language specific text
+    const parent = ul.parentNode;
+    const placeholders = await fetchPlaceholders();
+    const followMe = document.createElement('p');
+    followMe.classList.add('social-links-text');
+    followMe.textContent = placeholders.social;
+    parent.prepend(followMe);
+  }
 }


### PR DESCRIPTION
## Description

- add email support in social links block
- add language specific proceeding text

## Links

before: https://main--blog--adobe.hlx3.page/en/authors/lucinda-parish
after: https://social-links--blog--adobe.hlx3.page/en/authors/lucinda-parish
