### PR TITLE
fix: store placeholders in window obj to reduce repeat calls

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1144,13 +1144,15 @@ export async function getBlogArticle(path) {
  */
 
 export async function fetchPlaceholders() {
-  const resp = await fetch(`${getRootPath()}/placeholders.json`);
-  const json = await resp.json();
-  const placeholders = {};
-  json.data.forEach((placeholder) => {
-    placeholders[placeholder.Key] = placeholder.Text;
-  });
-  return (placeholders);
+  if (!window.placeholders) {
+    const resp = await fetch(`${getRootPath()}/placeholders.json`);
+    const json = await resp.json();
+    window.placeholders = {};
+    json.data.forEach((placeholder) => {
+      window.placeholders[placeholder.Key] = placeholder.Text;
+    });
+  }
+  return window.placeholders;
 }
 
 /**


### PR DESCRIPTION
## Description

Port adobe/business-website#134.

## Related Issue

#107 

## Links 

https://cache-placeholders--blog--adobe.hlx3.page/
https://cache-placeholders--blog--adobe.hlx3.page/?lighthouse=on