### PR TITLE
Intersection Observer Support for RUM

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -16,7 +16,7 @@
  * @param {Object} data additional data for RUM sample
  */
 
-const RUM_GENERATION = 'blog-gen-4';
+const RUM_GENERATION = 'blog-gen-5-intersection';
 
 export function sampleRUM(checkpoint, data = {}) {
   try {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -69,7 +69,10 @@ document.addEventListener('click', () => sampleRUM('click'));
 const mediaobserver = new IntersectionObserver((entries) => {
   entries
     .filter((entry) => entry.isIntersecting)
-    .forEach((entry) => sampleRUM('viewmedia', { target: entry.target.querySelector('img').currentSrc }));
+    .forEach((entry) => {
+      console.log(`seen: ${entry.target.querySelector('img').currentSrc}`);
+      sampleRUM('viewmedia', { target: entry.target.querySelector('img').currentSrc });
+    });
 }, { threshold: 0.25 });
 
 const blockobserver = new IntersectionObserver((entries) => {
@@ -979,6 +982,7 @@ export function createOptimizedPicture(src, alt = '', eager = false, breakpoints
   });
 
   mediaobserver.observe(picture);
+  console.log(`observe ${picture.querySelector('img').currentSrc}`);
   return picture;
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -78,8 +78,6 @@ const blockobserver = new IntersectionObserver((entries) => {
     .forEach((entry) => sampleRUM('viewblock', { target: entry.target.className }))
 }, { threshold: 0.25 });
 
-IntersectionObserverEntry
-
 /**
  * Loads a CSS file.
  * @param {string} href The path to the CSS file

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1066,7 +1066,7 @@ function decoratePictures(main) {
     const newPicture = createOptimizedPicture(img.src, img.alt, !i);
     const picture = img.closest('picture');
     if (picture) picture.parentElement.replaceChild(newPicture, picture);
-    mediaobserver.observe(picture || newPicture);
+    mediaobserver.observe(newPicture || picture);
   });
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -65,13 +65,19 @@ export function sampleRUM(checkpoint, data = {}) {
 sampleRUM.mediaobserver = (window.IntersectionObserver) ? new IntersectionObserver((entries) => {
   entries
     .filter((entry) => entry.isIntersecting)
-    .forEach((entry) => sampleRUM('viewmedia', { target: entry.target.querySelector('img').currentSrc }));
+    .forEach((entry) => {
+      sampleRUM.mediaobserver.unobserve(entry.target); // observe only once
+      sampleRUM('viewmedia', { target: entry.target.querySelector('img').currentSrc });
+    });
 }, { threshold: 0.25 }) : { observe: () => {} };
 
 sampleRUM.blockobserver = (window.IntersectionObserver) ? new IntersectionObserver((entries) => {
   entries
     .filter((entry) => entry.isIntersecting)
-    .forEach((entry) => sampleRUM('viewblock', { target: (entry.target.getAttribute('data-block-name') || entry.target.className) }));
+    .forEach((entry) => {
+      sampleRUM.blockobserver.unobserve(entry.target); // observe only once
+      sampleRUM('viewblock', { target: (entry.target.getAttribute('data-block-name') || entry.target.className) });
+    });
 }, { threshold: 0.25 }) : { observe: () => {} };
 
 sampleRUM.observe = ((elements) => {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -71,13 +71,8 @@ const mediaobserver = new IntersectionObserver((entries) => {
     .filter((entry) => entry.isIntersecting)
     .forEach((entry) => {
       if (entry.target.querySelector('img').currentSrc) {
-        console.log(`seen: ${entry.target.querySelector('img').currentSrc}`);
-      } else {
-        console.log('seen:');
-        console.log(entry.target);
-        console.log(entry.target.querySelector('img'));
+        console.log(`seen: ${entry.target.querySelector('img').currentSrc} (${entry.target.querySelector('img').alt})`);
       }
-
       sampleRUM('viewmedia', { target: entry.target.querySelector('img').currentSrc });
     });
 }, { threshold: 0.25 });
@@ -990,9 +985,6 @@ export function createOptimizedPicture(src, alt = '', eager = false, breakpoints
     }
   });
 
-  mediaobserver.observe(picture);
-  console.log('observe');
-  console.log(picture.outerHTML);
   return picture;
 }
 
@@ -1074,6 +1066,7 @@ function decoratePictures(main) {
     const newPicture = createOptimizedPicture(img.src, img.alt, !i);
     const picture = img.closest('picture');
     if (picture) picture.parentElement.replaceChild(newPicture, picture);
+    mediaobserver.observe(picture || newPicture);
   });
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -69,7 +69,7 @@ document.addEventListener('click', () => sampleRUM('click'));
 const mediaobserver = new IntersectionObserver((entries) => {
   entries
     .filter((entry) => entry.isIntersecting)
-    .forEach((entry) => sampleRUM('viewmedia', { target: entry.target.src }))
+    .forEach((entry) => sampleRUM('viewmedia', { target: entry.target.querySelector('img').currentSrc }))
 }, { threshold: 0.25 });
 
 const blockobserver = new IntersectionObserver((entries) => {
@@ -978,7 +978,7 @@ export function createOptimizedPicture(src, alt = '', eager = false, breakpoints
     }
   });
 
-  mediaobserver.observe(picture.querySelector('img'));
+  mediaobserver.observe(picture);
   return picture;
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -69,13 +69,13 @@ document.addEventListener('click', () => sampleRUM('click'));
 const mediaobserver = new IntersectionObserver((entries) => {
   entries
     .filter((entry) => entry.isIntersecting)
-    .forEach((entry) => sampleRUM('viewmedia', { target: entry.target.querySelector('img').currentSrc }))
+    .forEach((entry) => sampleRUM('viewmedia', { target: entry.target.querySelector('img').currentSrc }));
 }, { threshold: 0.25 });
 
 const blockobserver = new IntersectionObserver((entries) => {
   entries
     .filter((entry) => entry.isIntersecting)
-    .forEach((entry) => sampleRUM('viewblock', { target: entry.target.className }))
+    .forEach((entry) => sampleRUM('viewblock', { target: entry.target.className }));
 }, { threshold: 0.25 });
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -538,6 +538,7 @@ export function decorateBlock(block) {
 
   block.classList.add('block');
   block.setAttribute('data-block-name', blockName);
+  blockobserver.observe(block);
 }
 
 /**
@@ -977,6 +978,7 @@ export function createOptimizedPicture(src, alt = '', eager = false, breakpoints
     }
   });
 
+  mediaobserver.observe(picture.querySelector('img'));
   return picture;
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1070,6 +1070,10 @@ function decoratePictures(main) {
   });
 }
 
+function observePictures(main) {
+  main.querySelectorAll('picture').forEach((picture) => mediaobserver.observe(picture));
+}
+
 /**
  * Decorates the main element.
  * @param {Element} main The main element
@@ -1082,6 +1086,7 @@ export function decorateMain(main) {
   removeEmptySections();
   wrapSections(main.querySelectorAll(':scope > div'));
   decorateBlocks(main);
+  observePictures(main);
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -82,6 +82,8 @@ const mediaobserver = new IntersectionObserver((entries) => {
     });
 }, { threshold: 0.25 });
 
+window.mediaobserver = mediaobserver;
+
 const blockobserver = new IntersectionObserver((entries) => {
   entries
     .filter((entry) => entry.isIntersecting)

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -70,7 +70,14 @@ const mediaobserver = new IntersectionObserver((entries) => {
   entries
     .filter((entry) => entry.isIntersecting)
     .forEach((entry) => {
-      console.log(`seen: ${entry.target.querySelector('img').currentSrc}`);
+      if (entry.target.querySelector('img').currentSrc) {
+        console.log(`seen: ${entry.target.querySelector('img').currentSrc}`);
+      } else {
+        console.log('seen:');
+        console.log(entry.target);
+        console.log(entry.target.querySelector('img'));
+      }
+
       sampleRUM('viewmedia', { target: entry.target.querySelector('img').currentSrc });
     });
 }, { threshold: 0.25 });

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -992,7 +992,7 @@ export function createOptimizedPicture(src, alt = '', eager = false, breakpoints
 
   mediaobserver.observe(picture);
   console.log('observe');
-  console.log(picture);
+  console.log(picture.outerHTML);
   return picture;
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -991,7 +991,8 @@ export function createOptimizedPicture(src, alt = '', eager = false, breakpoints
   });
 
   mediaobserver.observe(picture);
-  console.log(`observe ${picture.querySelector('img').currentSrc}`);
+  console.log('observe');
+  console.log(picture);
   return picture;
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -66,6 +66,20 @@ sampleRUM('top');
 window.addEventListener('load', () => sampleRUM('load'));
 document.addEventListener('click', () => sampleRUM('click'));
 
+const mediaobserver = new IntersectionObserver((entries) => {
+  entries
+    .filter((entry) => entry.isIntersecting)
+    .forEach((entry) => sampleRUM('viewmedia', { target: entry.target.src }))
+}, { threshold: 0.25 });
+
+const blockobserver = new IntersectionObserver((entries) => {
+  entries
+    .filter((entry) => entry.isIntersecting)
+    .forEach((entry) => sampleRUM('viewblock', { target: entry.target.className }))
+}, { threshold: 0.25 });
+
+IntersectionObserverEntry
+
 /**
  * Loads a CSS file.
  * @param {string} href The path to the CSS file


### PR DESCRIPTION
This PR adds the ability to track individual media and block impressions using RUM data. It introduces a new 
`target` property in the RUM payload that is either the image URL or the block name, and it gets fired in
combination with the `viewmedia` and `viewblock` checkpoints that get triggered when either DOM element is at
least 25% visible in the viewport.

With this PR we will be able to get authors and developers feedback on which compontents and images get seen
most frequently, although a corresponding change in `helix-rum-collector` is needed to allow the `target` property.

Test URLs: 
- https://rumio--blog--adobe.hlx3.page/en/publish/2021/10/26/max-2021-photography-releases?rum=on#gs.gxlcl6
- https://rumio--blog--adobe.hlx3.page/?rum=on

Scroll around in the page and inspect the request payload of the RUM requests for details.
