### PR TITLE
chore: switch to new outer CDN

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
 
       - helix-post-deploy/monitoring:
           newrelic_name: Adobe Blog - Content (live)
-          newrelic_url: https://theblog--adobe.hlx.live
+          newrelic_url: https://main--blog--adobe.hlx.live
           newrelic_type: browser
           newrelic_script: ./monitoring/content-check.js
           newrelic_group_policy: Customer Sites


### PR DESCRIPTION
https://rofe-patch-1--blog--adobe.hlx3.page/
