### PR TITLE
fix: handle fetch errors in getMetadataJson

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -273,8 +273,14 @@ export function debug(message) {
  * @returns {Object} containing sanitized meta data
  */
 async function getMetadataJson(path) {
-  const resp = await fetch(path.split('.')[0]);
-  if (resp.ok) {
+  let resp;
+  try {
+    resp = await fetch(path.split('.')[0]);
+  } catch {
+    debug(`Could not retrieve metadata for ${path}`);
+  }
+
+  if (resp && resp.ok) {
     const text = await resp.text();
     const headStr = text.split('<head>')[1].split('</head>')[0];
     const head = document.createElement('head');


### PR DESCRIPTION
## Description
Some related articles have a redirect in place and fetch will throw CORS errors. The change will handle the use-case and stop execution (ignore the errors).

https://fix-related-fetch--blog--adobe.hlx3.page/

## Motivation and Context
Code should not have unhandled errors.

## How Has This Been Tested?
Locally

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/408175/143243210-77ac2e40-402b-4549-953b-3e184ae710c5.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
