### PR TITLE
chore: show redirected cards in recommended articles

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -273,7 +273,7 @@ export function debug(message) {
  * @returns {Object} containing sanitized meta data
  */
 async function getMetadataJson(path) {
-  const resp = await fetch(path.split('.')[0]);
+  const resp = await fetch(`${path.split('.')[0]}?noredirect`);
   if (resp.ok) {
     const text = await resp.text();
     const headStr = text.split('<head>')[1].split('</head>')[0];


### PR DESCRIPTION
https://main--blog--adobe.hlx.live/en/publish/2021/11/23/adobe-mlb-partner-next-gen-fan-experiences#gs.gwj35t

vs. 

https://show-redirected-cards--blog--adobe.hlx.live/en/publish/2021/11/23/adobe-mlb-partner-next-gen-fan-experiences#gs.gwj35t