### PR TITLE
feat(rum): add `target` attribute to click event tracking

### DIFF
--- a/blocks/tags/tags.js
+++ b/blocks/tags/tags.js
@@ -1,10 +1,15 @@
+import { sampleRUM } from '../../scripts/scripts.js';
+
 export default function decorateTags(blockEl) {
   const tags = blockEl.querySelectorAll('a');
   const container = blockEl.querySelector('p');
   container.classList.add('tags-container');
   container.textContent = '';
-  tags.forEach((tag) => {
+  const target = Array.from(tags).reduce((targets, tag) => {
     tag.classList.add('button');
     container.append(tag);
-  });
+    targets.push(tag.href);
+    return targets;
+  }, []).join('; ');
+  sampleRUM('loadtags', { target, source: `.${blockEl.getAttribute('data-block-name')}` });
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -302,12 +302,12 @@ export function getHelixEnv() {
   return env;
 }
 
-export function debug(message) {
+export function debug(message, ...args) {
   const { hostname } = window.location;
   const env = getHelixEnv();
   if (env.name !== 'prod' || hostname === 'localhost') {
     // eslint-disable-next-line no-console
-    console.log(message);
+    console.log(message, ...args);
   }
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -134,6 +134,8 @@ window.onerror = (event, source, line) => {
   // keep the old error handler around
   if (typeof olderror === 'function') {
     olderror(event, source, line);
+  } else {
+    throw new Error(event);
   }
 };
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -128,6 +128,15 @@ document.addEventListener('click', (event) => {
   });
 });
 
+const olderror = window.onerror;
+window.onerror = (event, source, line) => {
+  sampleRUM('error', { source, target: line });
+  // keep the old error handler around
+  if (typeof olderror === 'function') {
+    olderror(event, source, line);
+  }
+};
+
 /**
  * Loads a CSS file.
  * @param {string} href The path to the CSS file


### PR DESCRIPTION
extracts a CSS selector for the element that has been clicked and shares it as the RUM events `target` value, as requested by @davidnuescheler in yesterday's show & tell.

Test URL: https://rum-click-interceptor--blog--adobe.hlx.live/?rum=on