### PR TITLE
fix: embed different type of slideshare url

### DIFF
--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -103,7 +103,13 @@ const embedSlideShare = (url) => {
         </div>`;
     }
   };
-  slideShareBuild(url);
+  if (url.href.includes('embed_code')) {
+    resultHtml.innerHTML = `<div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;">
+      <iframe src="${url}" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" allowfullscreen loading="lazy"> </iframe>
+    </div>`;
+  } else {
+    slideShareBuild(url);
+  }
 
   return resultHtml.outerHTML;
 };


### PR DESCRIPTION
## Description

allow for different type of slideshare link (circumvent slideshare fetch)

## Links 
https://slideshare-embed--blog--adobe.hlx3.page/en/publish/2021/07/23/announcing-2021-sundance-ignite-x-adobe-fellows