### PR TITLE
feat: add temp title substitutes

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -417,6 +417,10 @@ export function getTaxonomy() {
  * @returns {string} A link tag as a string
  */
 export function getLinkForTopic(topic, path) {
+  // temporary title substitutions
+  const titleSubs = {
+    'Transformation digitale': 'Transformation numérique',
+  };
   let catLink;
   if (taxonomy) {
     const tax = taxonomy.get(topic);
@@ -429,7 +433,7 @@ export function getLinkForTopic(topic, path) {
     }
   }
 
-  return `<a href="${catLink || ''}" ${!catLink ? `data-topic-link="${topic}"` : ''}>${topic}</a>`;
+  return `<a href="${catLink || ''}" ${!catLink ? `data-topic-link="${topic}"` : ''}>${titleSubs[topic] || topic}</a>`;
 }
 
 /**


### PR DESCRIPTION
Temporary substitution of the french topic title 'transformation digitale' to 'transformation numérique' (display only).

Before: https://main--blog--adobe.hlx3.page/fr/publish/2021/11/17/volvo-cars-modernise-ses-services-grace-a-adobe-sign
After: https://topic-subs--blog--adobe.hlx3.page/fr/publish/2021/11/17/volvo-cars-modernise-ses-services-grace-a-adobe-sign