### PR TITLE
fix: hide unobserved embed block links

### DIFF
--- a/blocks/embed/embed.css
+++ b/blocks/embed/embed.css
@@ -22,6 +22,11 @@ main .embed img {
   max-width: 100%;
 }
 
+main .embed > div > div p a {
+  visibility: hidden;
+  word-break: break-word;
+}
+
 main .embed.embed-instagram {
   max-width: fit-content;
 }


### PR DESCRIPTION
## Description

unobserved embeds display the link before the embed iframe is created, resulting in righthand side whitespace on blog posts with embeds before the embeds are viewed

propose hide and break the embed links to prevent whitespace 

## Link
https://unobserved-embeds--blog--adobe.hlx3.page/en/publish/2021/12/13/introducing-creative-cloud-express
