### PR TITLE
fix: load privacy once

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1360,7 +1360,6 @@ async function loadLazy() {
   loadBlocks(main);
   loadCSS('/styles/lazy-styles.css');
   addFavIcon('/styles/favicon.svg');
-  loadPrivacy();
 
   if (window.location.pathname.endsWith('/')) {
     // homepage, add query index to publish dependencies


### PR DESCRIPTION
## Description
The Privacy script was loaded twice:
* at load - https://github.com/adobe/blog/blob/main/scripts/scripts.js#L1304
* after some time via lazyload - https://github.com/adobe/blog/blob/main/scripts/scripts.js#L1363

https://privacy-issue--blog--adobe.hlx3.page/

## How Has This Been Tested?
locally

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
