### PR TITLE
feat: highlight invalid dates in preview

### DIFF
--- a/blocks/article-header/article-header.css
+++ b/blocks/article-header/article-header.css
@@ -132,6 +132,7 @@ main .article-date {
 }
 
 main .article-date.article-date-invalid {
+  position: relative;
   padding: 0 5px;
   border: 10px solid red;
   background: yellow;

--- a/blocks/article-header/article-header.css
+++ b/blocks/article-header/article-header.css
@@ -131,6 +131,12 @@ main .article-date {
   font-weight: 300;
 }
 
+main .article-date.article-date-invalid {
+  padding: 0 5px;
+  border: 10px solid red;
+  background: yellow;
+}
+
 /* feature img */
 
 main .article-header .article-feature-image {

--- a/blocks/article-header/article-header.js
+++ b/blocks/article-header/article-header.js
@@ -38,6 +38,15 @@ async function populateAuthorInfo(authorLink, imgContainer, url, name, eager = f
   }
 }
 
+function validateDate(date) {
+  if (date && !window.location.hostname.includes('adobe.com')) {
+    const [mm, dd, yyyy] = date.textContent.split('-');
+    if (!window.location.pathname.includes(`/${yyyy}/${mm}/${dd}/`)) {
+      date.classList.add('article-date-invalid');
+    }
+  }
+}
+
 export default async function decorateArticleHeader(blockEl, blockName, document, eager) {
   const childrenEls = Array.from(blockEl.children);
   // category
@@ -59,6 +68,7 @@ export default async function decorateArticleHeader(blockEl, blockName, document
   // publication date
   const date = bylineContainer.firstChild.lastChild;
   date.classList.add('article-date');
+  validateDate(date);
   // author img
   const authorImg = document.createElement('div');
   authorImg.classList = 'article-author-image';

--- a/blocks/article-header/article-header.js
+++ b/blocks/article-header/article-header.js
@@ -1,6 +1,7 @@
 import {
   buildFigure,
   createOptimizedPicture,
+  fetchPlaceholders,
 } from '../../scripts/scripts.js';
 
 async function populateAuthorInfo(authorLink, imgContainer, url, name, eager = false) {
@@ -42,10 +43,12 @@ function validateDate(date) {
   if (date
     && !window.location.hostname.includes('adobe.com')
     && window.location.pathname.includes('/publish/')) {
-    // match publication date to date in pathname
-    const [mm, dd, yyyy] = date.textContent.split('-');
-    if (!window.location.pathname.includes(`/${yyyy}/${mm}/${dd}/`)) {
+    // match publication date to MM-DD-YYYY format
+    if (!/[0-1]\d{1}-[0-3]\d{1}-[2]\d{3}/.test(date.textContent.trim())) {
       date.classList.add('article-date-invalid');
+      fetchPlaceholders().then((placeholders) => {
+        date.setAttribute('title', placeholders['invalid-date']);
+      });
     }
   }
 }

--- a/blocks/article-header/article-header.js
+++ b/blocks/article-header/article-header.js
@@ -39,7 +39,10 @@ async function populateAuthorInfo(authorLink, imgContainer, url, name, eager = f
 }
 
 function validateDate(date) {
-  if (date && !window.location.hostname.includes('adobe.com')) {
+  if (date
+    && !window.location.hostname.includes('adobe.com')
+    && window.location.pathname.includes('/publish/')) {
+    // match publication date to date in pathname
     const [mm, dd, yyyy] = date.textContent.split('-');
     if (!window.location.pathname.includes(`/${yyyy}/${mm}/${dd}/`)) {
       date.classList.add('article-date-invalid');


### PR DESCRIPTION
## Description

- reinstate invalid date highlight in preview (when metadata publication date does not match date in pathname)

## Screenshots and Links

<img width="483" alt="invalid date styling" src="https://user-images.githubusercontent.com/43383503/154542981-cfd9d187-3ff8-48f1-a0a5-8774108e1724.png">


invalid date: https://highlight-incorrect-date--blog--adobe.hlx3.page/en/drafts/katie/publish/2022/02/02/adobe-one-of-worlds-most-admired-companies
valid date: https://main--blog--adobe.hlx3.page/en/drafts/katie/publish/2022/02/02/how-young-chae-embraces-new-obstacles-as-an-opportunity-to-learn-and-grow
