### PR TITLE
chore: move custom buttons to tools menu

### DIFF
--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -210,6 +210,7 @@ window.hlx.initSidekick({
     // TOOLS DROPDOWN -----------------------------------------------------------------
     {
       id: 'tools',
+      condition: (sk) => !sk.isEditor(),
       button: {
         text: 'Tools',
         isDropdown: true,
@@ -219,7 +220,6 @@ window.hlx.initSidekick({
     {
       id: 'tagger',
       condition: (sk) => sk.isEditor() && (sk.location.search.includes('.docx&') || sk.location.search.includes('.md&')),
-      container: 'tools',
       button: {
         text: 'Tagger',
         action: (_, sk) => {

--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -41,7 +41,7 @@ const toggleCardPreview = async (sk) => {
     const {
       getBlogArticle,
       buildArticleCard,
-    } = await import('/scripts/scripts.js');
+    } = await import(`${window.location.origin}/scripts/scripts.js`);
     $modal.append(buildArticleCard(await getBlogArticle(sk.location.pathname)));
 
     const $overlay = document.createElement('div');
@@ -58,7 +58,7 @@ const toggleCardPreview = async (sk) => {
 const predictUrl = async (host, path) => {
   const {
     getBlogArticle,
-  } = await import('/scripts/scripts.js');
+  } = await import(`${window.location.origin}/scripts/scripts.js`);
   const pathsplits = path.split('/');
   let publishPath = '';
   const article = await getBlogArticle(path);
@@ -75,7 +75,7 @@ const predictUrl = async (host, path) => {
 const copyArticleData = async (sk) => {
   const {
     getBlogArticle,
-  } = await import('/scripts/scripts.js');
+  } = await import(`${window.location.origin}/scripts/scripts.js`);
   const { location, status } = sk;
   const {
     date,
@@ -207,10 +207,19 @@ window.hlx.initSidekick({
   host: 'blog.adobe.com',
   pushDownSelector: 'header',
   plugins: [
+    // TOOLS DROPDOWN -----------------------------------------------------------------
+    {
+      id: 'tools',
+      button: {
+        text: 'Tools',
+        isDropdown: true,
+      },
+    },
     // TAGGER -------------------------------------------------------------------------
     {
       id: 'tagger',
       condition: (sk) => sk.isEditor() && (sk.location.search.includes('.docx&') || sk.location.search.includes('.md&')),
+      container: 'tools',
       button: {
         text: 'Tagger',
         action: (_, sk) => {
@@ -223,6 +232,7 @@ window.hlx.initSidekick({
     {
       id: 'card-preview',
       condition: (sidekick) => sidekick.isHelix() && isArticle(sidekick.location.pathname),
+      container: 'tools',
       button: {
         text: 'Card Preview',
         action: async (_, sk) => toggleCardPreview(sk),
@@ -238,6 +248,7 @@ window.hlx.initSidekick({
           && config.host
           && location.host !== config.host;
       },
+      container: 'tools',
       button: {
         text: 'Copy Predicted URL',
         action: async (_, sk) => {
@@ -255,6 +266,7 @@ window.hlx.initSidekick({
     {
       id: 'article-data',
       condition: (sidekick) => sidekick.isHelix() && isArticle(sidekick.location.pathname),
+      container: 'tools',
       button: {
         text: 'Copy Article Data',
         action: async (_, sk) => copyArticleData(sk),
@@ -270,6 +282,7 @@ window.hlx.initSidekick({
     {
       id: 'feed',
       condition: () => hasFeed(),
+      container: 'tools',
       button: {
         text: 'Update Feed',
         action: async (_, sk) => updateFeed(sk),


### PR DESCRIPTION
Move custom plugins to tools dropdown to free up space.

<img width="326" alt="image" src="https://user-images.githubusercontent.com/1609742/155367532-faf3d75a-5044-4be3-8dae-c6d344548451.png">

Related to https://github.com/adobe/helix-sidekick/issues/263

https://sk-tools--blog--adobe.hlx3.page/?martech=off