### PR TITLE
fix: js error on most of the pages when checking external links

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -136,10 +136,15 @@ sampleRUM('cwv');
 
 function updateExternalLinks() {
   document.querySelectorAll('main a').forEach((a) => {
-    const { origin } = new URL(a);
-    if (origin && origin !== window.location.origin) {
-      a.setAttribute('rel', 'noopener');
-      a.setAttribute('target', '_blank');
+    try {
+      const { origin } = new URL(a.href);
+      if (origin && origin !== window.location.origin) {
+        a.setAttribute('rel', 'noopener');
+        a.setAttribute('target', '_blank');
+      }
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn(`Invalid link: ${a.href}`);
     }
   });
 }


### PR DESCRIPTION
No clue how we have not seen that before!

Test: 

https://blog.adobe.com/en/publish/2022/03/08/adobe-named-one-of-worlds-most-innovative-companies-in-ai-by-fast-company

vs

https://fix-external-links--blog--adobe.hlx3.page/en/publish/2022/03/08/adobe-named-one-of-worlds-most-innovative-companies-in-ai-by-fast-company

