### PR TITLE
feat: make links relative

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -1,7 +1,7 @@
 import {
   fetchPlaceholders,
   debug,
-  adjustLinks,
+  makeLinksRelative,
 } from '../../scripts/scripts.js';
 import createTag from '../gnav/gnav-utils.js';
 
@@ -34,7 +34,7 @@ class Footer {
       infoRow.classList.add('has-region');
     }
 
-    adjustLinks(region);
+    makeLinksRelative(region);
 
     const social = this.decorateSocial();
     if (social) {

--- a/blocks/gnav/gnav.js
+++ b/blocks/gnav/gnav.js
@@ -2,7 +2,7 @@ import {
   loadScript,
   getHelixEnv,
   debug,
-  adjustLinks,
+  makeLinksRelative,
   getLocale,
 } from '../../scripts/scripts.js';
 import createTag from './gnav-utils.js';
@@ -54,7 +54,7 @@ class Gnav {
       nav.append(logo);
     }
 
-    adjustLinks(nav);
+    makeLinksRelative(nav);
 
     const wrapper = createTag('div', { class: 'gnav-wrapper' }, nav);
     this.el.append(this.curtain, wrapper);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -18,6 +18,8 @@
 
 const RUM_GENERATION = 'blog-gen-7-highrate';
 
+const PRODUCTION_DOMAINS = ['blog.adobe.com'];
+
 export function sampleRUM(checkpoint, data = {}) {
   try {
     window.hlx = window.hlx || {};
@@ -155,23 +157,25 @@ export function loadCSS(href) {
 }
 
 /**
- * Adjust all links inside the container to point to current
- * host and not to blog.adobe.com (useful on localhost and authoring host)
- * @param {Element} container The element in which links will be adusted
+ * Turns absolute links within the domain into relative links.
+ * @param {Element} main The container element
  */
-export function adjustLinks(container) {
-  if (container && window.location.host !== 'blog.adobe.com') {
-    container.querySelectorAll('a').forEach((a) => {
+export function makeLinksRelative(main) {
+  main.querySelectorAll('a').forEach((a) => {
+    // eslint-disable-next-line no-use-before-define
+    const hosts = ['hlx3.page', 'hlx.page', 'hlx.live', ...PRODUCTION_DOMAINS];
+    if (a.href) {
       try {
-        if (a.href) {
-          const u = new URL(a.href);
-          a.href = `${window.location.origin}${u.pathname}`;
-        }
+        const url = new URL(a.href);
+        const relative = hosts.some((host) => url.hostname.includes(host));
+        if (relative) a.href = `${url.pathname}${url.search}${url.hash}`;
       } catch (e) {
-        // ignore
+        // something went wrong
+        // eslint-disable-next-line no-console
+        console.log(e);
       }
-    });
-  }
+    }
+  });
 }
 
 const LANG = {
@@ -1153,6 +1157,7 @@ function decoratePictures(main) {
 export function decorateMain(main) {
   // forward compatible pictures redecoration
   decoratePictures(main);
+  makeLinksRelative(main);
   buildAutoBlocks(main);
   splitSections();
   removeEmptySections();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -168,7 +168,9 @@ export function makeLinksRelative(main) {
       try {
         const url = new URL(a.href);
         const relative = hosts.some((host) => url.hostname.includes(host));
-        if (relative) a.href = `${url.pathname}${url.search}${url.hash}`;
+        if (relative) {
+          a.href = `${url.pathname.replace(/\.html$/, '')}${url.search}${url.hash}`;
+        }
       } catch (e) {
         // something went wrong
         // eslint-disable-next-line no-console


### PR DESCRIPTION
Port https://github.com/adobe/helix-project-boilerplate/pull/70
I have also included the removal of the `.html`.

This could potentially break a lot...


Test - (Stephan Hawthorne link at the top + all links...):

https://blog.adobe.com/en/publish/2020/10/08/adobe-photography-releases-october-2020

vs

https://make-links-relative--blog--adobe.hlx3.page/en/publish/2020/10/08/adobe-photography-releases-october-2020