### PR TITLE
fix: 

### DIFF
--- a/blocks/animation/animation.js
+++ b/blocks/animation/animation.js
@@ -3,8 +3,8 @@ import { buildFigure } from '../../scripts/scripts.js';
 export default function decorateAnimation(blockEl) {
   const a = blockEl.querySelector('a');
   const parentEl = a.parentNode;
-  const href = a.textContent;
-  const url = new URL(href);
+  const href = a.getAttribute('href');
+  const url = new URL(href, window.location.href);
   const { hostname } = url;
   let { pathname } = url;
 

--- a/blocks/animation/animation.js
+++ b/blocks/animation/animation.js
@@ -3,7 +3,7 @@ import { buildFigure } from '../../scripts/scripts.js';
 export default function decorateAnimation(blockEl) {
   const a = blockEl.querySelector('a');
   const parentEl = a.parentNode;
-  const href = a.getAttribute('href');
+  const href = a.textContent;
   const url = new URL(href);
   const { hostname } = url;
   let { pathname } = url;

--- a/blocks/video/video.js
+++ b/blocks/video/video.js
@@ -6,8 +6,8 @@ export default function decorate(block) {
   }
   const poster = block.querySelector('img') ? `poster="${block.querySelector('img').src}"` : '';
   const a = block.querySelector('a');
-  const href = a.textContent;
-  const url = new URL(href);
+  const href = a.getAttribute('href');
+  const url = new URL(href, window.location.href);
   const { hostname } = url;
   let { pathname } = url;
 

--- a/blocks/video/video.js
+++ b/blocks/video/video.js
@@ -6,8 +6,7 @@ export default function decorate(block) {
   }
   const poster = block.querySelector('img') ? `poster="${block.querySelector('img').src}"` : '';
   const a = block.querySelector('a');
-
-  const href = a.getAttribute('href');
+  const href = a.textContent;
   const url = new URL(href);
   const { hostname } = url;
   let { pathname } = url;


### PR DESCRIPTION
## Description

making links relative so early broke the way video and animation blocks were created
these blocks now create new URLs with the `window.location.href`

## Link
before: https://blog.adobe.com/en/publish/2022/03/14/fostering-future-facing-learning-in-higher-education-key-takeaways-from-digital-literacy-cafe-webinar

after: https://vid-anim-blocks--blog--adobe.hlx.live/en/publish/2022/03/14/fostering-future-facing-learning-in-higher-education-key-takeaways-from-digital-literacy-cafe-webinar