### PR TITLE
Fix Javascript error

### DIFF
--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -179,10 +179,10 @@ export default function decorate($block) {
     let $caption = null;
     let nextElement = $picture.nextElementSibling;
     if (nextElement && !nextElement.tagName.toLowerCase() !== 'picture') {
-      while (nextElement.tagName.toLowerCase() !== 'picture' && (nextElement.childNodes.length === 0 || nextElement.textContent === '')) {
+      while (nextElement && nextElement.tagName.toLowerCase() !== 'picture' && (nextElement.childNodes.length === 0 || nextElement.textContent === '')) {
         nextElement = nextElement.nextElementSibling;
       }
-      if (nextElement.childNodes.length !== 0 && nextElement.textContent !== '') $caption = nextElement;
+      if (nextElement && nextElement.childNodes.length !== 0 && nextElement.textContent !== '') $caption = nextElement;
     }
     $imgSlides.push({ img: $picture, caption: $caption });
     // Find the aspect ratio of the shortest image


### PR DESCRIPTION
Quick fix for the Javascript error that sometimes happens in the carousel block (`cannot read .tagName of null`)

Test URLs:
- Before: https://main--blog--adobe.hlx.page/en/drafts/solene/carousel
- After: https://fix-js-error--blog--webistry-development.hlx.page/en/drafts/solene/carousel