### PR TITLE
Added link color rules for after carousel

### DIFF
--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -61,7 +61,7 @@ main div.carousel-container + div a:any-link:not([class]) {
 }
 
 main div.article-header-container + div a:hover:not([class]),
-main div.article-header-container + div a:focus:not([class])
+main div.article-header-container + div a:focus:not([class]),
 main div.carousel-container + div a:hover:not([class]),
 main div.carousel-container + div a:focus:not([class]) {
   color: var(--color-info-accent-hover);

--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -53,14 +53,17 @@
 .tk-adobe-clean { font-family: "adobe-clean", "Trebuchet MS", sans-serif; }
 .tk-adobe-clean-serif { font-family: "adobe-clean-serif", "Times New Roman", Times, serif; }
 
-main div.article-header-container + div a:any-link:not([class]) {
+main div.article-header-container + div a:any-link:not([class]),
+main div.carousel-container + div a:any-link:not([class]) {
   color: var(--color-info-accent);
   text-decoration: underline;
   text-decoration-thickness: 2px;
 }
 
 main div.article-header-container + div a:hover:not([class]),
-main div.article-header-container + div a:focus:not([class]) {
+main div.article-header-container + div a:focus:not([class])
+main div.carousel-container + div a:hover:not([class]),
+main div.carousel-container + div a:focus:not([class]) {
   color: var(--color-info-accent-hover);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Patch fix to ensure links below carousel are blue as expected. 

Before: https://main--blog--adobe.hlx.page/en/drafts/solene/carousel
After: https://carousel-link-fix--blog--adobe.hlx.page/en/drafts/solene/carousel

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
