### PR TITLE
fix(toolkit): safari mobile hotfix

### DIFF
--- a/blocks/toolkit/toolkit.css
+++ b/blocks/toolkit/toolkit.css
@@ -57,6 +57,10 @@ main .toolkit .container .row-content a.button {
     margin: 0;
 }
 
+main .toolkit .container .row-image {
+    display: flex;
+}
+
 main .toolkit .container .row-image img {
     max-width: 100px;
     display: block;


### PR DESCRIPTION
Description:
A fix to prevent images from going full height on Safari IOS.

Test URL:
https://toolkit-safari-hotfix--blog--webistry-development.hlx3.page/en/publish/2022/05/18/create-change-create-waves