### PR TITLE
fix: add safeguard to allow page to load if milo list fails to be retrieved

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1325,6 +1325,7 @@ async function loadLibs() {
       const { default: list } = await import(`${window.milo.libs.base}/blocks/list.js`);
       window.milo.libs.blocks = { list };
     } catch (e) {
+      window.milo.libs.blocks = {};
       console.log('Couldn\'t load libs list');
     }
   }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1326,6 +1326,7 @@ async function loadLibs() {
       window.milo.libs.blocks = { list };
     } catch (e) {
       window.milo.libs.blocks = {};
+      // eslint-disable-next-line no-console
       console.log('Couldn\'t load libs list');
     }
   }


### PR DESCRIPTION
For a japanese author, it appears that `https://main.milo.pink/libs/blocks/list.js` isn't accessible which leads to a JS error in the critical page loading sequence further downstream:
![image](https://user-images.githubusercontent.com/1609742/169794273-e6568982-748b-44cc-9b2a-7654a93223c2.png)
