### PR TITLE
fix: load plugins if sidekick is already there

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1383,9 +1383,13 @@ async function loadEager() {
       }
     });
   }
-  document.addEventListener('helix-sidekick-ready', () => {
+  if (document.querySelector('helix-sidekick')) {
     import('../tools/sidekick/plugins.js');
-  }, { once: true });
+  } else {
+    document.addEventListener('helix-sidekick-ready', () => {
+      import('../tools/sidekick/plugins.js');
+    }, { once: true });
+  }
 }
 
 /**


### PR DESCRIPTION
The sidekick can be loaded "too early", so we should check if it's already there before attaching the listener.

https://sk-mv3--blog--adobe.hlx.live/