### PR TITLE
chore: move privacy script post LCP

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1376,8 +1376,6 @@ function loadPrivacy() {
   loadScript(`https://www.${env}adobe.com/etc.clientlibs/globalnav/clientlibs/base/privacy-standalone.js`);
 }
 
-loadPrivacy();
-
 /**
  * Loads everything needed to get to LCP.
  */
@@ -1400,6 +1398,7 @@ async function loadEager() {
         resolve();
       }
     });
+    loadPrivacy();
   }
   if (document.querySelector('helix-sidekick')) {
     import('../tools/sidekick/plugins.js');


### PR DESCRIPTION
move privacy outside of the LCP critical path

https://main--blog--adobe.hlx.live/en/publish/2022/10/17/the-creative-event-of-year-here-register-free-adobe-max-2022
vs.
https://privacy-lcp--blog--adobe.hlx.live/en/publish/2022/10/17/the-creative-event-of-year-here-register-free-adobe-max-2022


<img width="503" alt="Screen Shot 2022-10-17 at 9 23 26 PM" src="https://user-images.githubusercontent.com/5289336/196320669-549c9bbe-6bbc-4b94-a216-7e7256f8ab09.png">
<img width="513" alt="Screen Shot 2022-10-17 at 9 23 45 PM" src="https://user-images.githubusercontent.com/5289336/196320703-00c72198-8a0d-4327-be87-e8894df7ca72.png">

the LCP values may be a bit misleading because of the impact of `main--milo--` origin, but i think the delta should stay the same, compared to blog.adobe.com.

<img width="531" alt="Screen Shot 2022-10-17 at 9 25 47 PM" src="https://user-images.githubusercontent.com/5289336/196320955-75cf5a9c-8e55-4c8d-867b-0c477ed5ebef.png">

meaning that there should be a positive LCP impact of about `500ms`
