### PR TITLE
Import the Milo Section Metadata block

### DIFF
--- a/blocks/section-metadata/section-metadata.css
+++ b/blocks/section-metadata/section-metadata.css
@@ -1,0 +1,96 @@
+.section-metadata {
+    display: none;
+}
+
+.section-wrapper.darkest {
+    background-color: rgb(0 0 0);
+    color: rgb(255 255 255);
+}
+
+.section-wrapper.dark {
+    background-color: rgb(29 29 29);
+    color: rgb(235 235 235);
+}
+
+.section-wrapper.light {
+    background-color: rgb(255 255 255);
+    color: rgb(34 34 34);
+}
+
+.section-wrapper.has-background {
+    background-color: unset;
+}
+
+.section-wrapper.xxl-spacing {
+    padding: var(--spacing-xxl) 0;
+}
+
+.section-wrapper.xl-spacing {
+    padding: var(--spacing-xl) 0;
+}
+
+.section-wrapper.l-spacing {
+    padding: var(--spacing-l) 0;
+}
+
+.section-wrapper.m-spacing {
+    padding: var(--spacing-m) 0;
+}
+
+.section-wrapper.s-spacing {
+    padding: var(--spacing-s) 0;
+}
+
+.section-wrapper.xs-spacing {
+    padding: var(--spacing-xs) 0;
+}
+
+.section-wrapper picture.section-background {
+    display: block;
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+}
+
+.section-wrapper .section-background img {
+    object-fit: cover;
+    height: 100%;
+    width: 100%;
+}
+
+.section-wrapper.center .content>h1,
+.section-wrapper.center .content>h2,
+.section-wrapper.center .content>h3,
+.section-wrapper.center .content>h4,
+.section-wrapper.center .content>h5,
+.section-wrapper.center .content>h6,
+.section-wrapper.center .content>p {
+    text-align: center;
+}
+
+.section-wrapper.divider {
+    border-bottom: 1px solid #d8d8d8;
+}
+
+.section-wrapper.two-up .grid,
+.section-wrapper.three-up .grid,
+.section-wrapper.four-up .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(276px, 1fr));
+}
+
+@media screen and (min-width: 1200px) {
+
+    .section-wrapper.two-up .grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .section-wrapper.three-up .grid {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    .section-wrapper.four-up .grid {
+        grid-template-columns: repeat(4, 1fr);
+    }
+
+}

--- a/blocks/section-metadata/section-metadata.css
+++ b/blocks/section-metadata/section-metadata.css
@@ -18,6 +18,7 @@
 }
 
 .section-wrapper.has-background {
+    position: relative;
     background-color: unset;
 }
 
@@ -58,13 +59,13 @@
     width: 100%;
 }
 
-.section-wrapper.center .content>h1,
-.section-wrapper.center .content>h2,
-.section-wrapper.center .content>h3,
-.section-wrapper.center .content>h4,
-.section-wrapper.center .content>h5,
-.section-wrapper.center .content>h6,
-.section-wrapper.center .content>p {
+.section-wrapper.center h1,
+.section-wrapper.center h2,
+.section-wrapper.center h3,
+.section-wrapper.center h4,
+.section-wrapper.center h5,
+.section-wrapper.center h6,
+.section-wrapper.center p {
     text-align: center;
 }
 

--- a/blocks/section-metadata/section-metadata.js
+++ b/blocks/section-metadata/section-metadata.js
@@ -1,0 +1,36 @@
+function handleBackground(div, section) {
+  const pic = div.querySelector('picture');
+  if (pic) {
+    section.classList.add('has-background');
+    pic.classList.add('section-background');
+    section.insertAdjacentElement('afterbegin', pic);
+  } else {
+    const color = div.textContent;
+    if (color) {
+      section.style.backgroundColor = color;
+    }
+  }
+}
+
+function handleStyle(div, section) {
+  const value = div.textContent.toLowerCase();
+  const styles = value.split(', ').map((style) => style.replaceAll(' ', '-'));
+  if (section) {
+    section.classList.add(...styles);
+  }
+}
+
+export default function decorate(el) {
+  const section = el.closest('.section-wrapper');
+  if (!section) return;
+  const keyDivs = el.querySelectorAll(':scope > div > div:first-child');
+  keyDivs.forEach((div) => {
+    const valueDiv = div.nextElementSibling;
+    if (div.textContent === 'style' && valueDiv.textContent) {
+      handleStyle(valueDiv, section);
+    }
+    if (div.textContent === 'background') {
+      handleBackground(valueDiv, section);
+    }
+  });
+}

--- a/blocks/section-metadata/section-metadata.js
+++ b/blocks/section-metadata/section-metadata.js
@@ -14,6 +14,7 @@ function handleBackground(div, section) {
 
 function handleStyle(div, section) {
   const value = div.textContent.toLowerCase();
+  console.log(value);
   const styles = value.split(', ').map((style) => style.replaceAll(' ', '-'));
   if (section) {
     section.classList.add(...styles);
@@ -25,6 +26,7 @@ export default function decorate(el) {
   if (!section) return;
   const keyDivs = el.querySelectorAll(':scope > div > div:first-child');
   keyDivs.forEach((div) => {
+    console.log(div.textContent);
     const valueDiv = div.nextElementSibling;
     if (div.textContent === 'style' && valueDiv.textContent) {
       handleStyle(valueDiv, section);


### PR DESCRIPTION
I’ve manually imported the “section-metadata” block in a way that accounts for all the DOM/class changes between Milo and Blog. You can preview the experience here in this cool little draft I've created:

Before:
https://main--blog--webistry-development.hlx.page/en/drafts/williambsm/tabs

After:
https://milo-section-metadata--blog--webistry-development.hlx.page/en/drafts/williambsm/tabs

I understand it's a slight modification of the block, but I'm hoping that by doing this we will reduce the amount of work required to retroactively fit Milo in the authoring experience and also allow the team to access the capabilities of this block sooner. 
