### PR TITLE
Milo marquee

### DIFF
--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -1,0 +1,436 @@
+.marquee {
+    position: relative;
+    color: #FFF;
+    display: flex;
+}
+
+.marquee.small, .marquee.quiet, .marquee.inline {
+    min-height: 360px;
+}
+
+.marquee.inline hr {
+    margin-top: var(--spacing-m);
+    margin-bottom: 0;
+}
+
+.marquee.light, .marquee.quiet, .marquee.inline {
+    color: var(--text-color);
+}
+
+.marquee.centered {
+    text-align: center;
+}
+
+.marquee.centered .foreground,
+.marquee.centered .action-area {
+    justify-content: center;
+}
+
+.marquee .background.has-video {
+    bottom: 0;
+    left: 0;
+    overflow: hidden;
+    position: absolute;
+    right: 0;
+    top: 0;
+}
+
+.marquee .background .mobileOnly.tabletOnly {
+    display: block;
+}
+
+.marquee .background .tabletOnly,
+.marquee .background .desktopOnly {
+    display: none;
+}
+
+.marquee .background picture {
+    display: block;
+    position: absolute;
+    inset: 0;
+    line-height: 0;
+}
+
+.marquee .background img {
+    object-fit: cover;
+    height: 100%;
+    width: 100%;
+}
+
+.marquee .background video {
+    display: block;
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+/* Split */
+.marquee.split {
+    flex-direction: column;
+}
+
+.marquee.split .media {
+    width: 100%;
+    margin: 0;
+}
+
+.marquee.split .media img,
+.marquee.split .media video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    max-height: 360px;
+}
+
+.marquee.split.small .foreground {
+    order: 1;
+}
+.marquee.split.small .media {
+    order: 2;
+}
+
+.marquee.split .media {
+    order: 0;
+}
+
+.marquee.split.large .heading-XXL {
+    margin-bottom: var(--spacing-s);
+}
+
+.marquee .foreground {
+    position: relative;
+    padding: var(--spacing-xxl) 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-m);
+}
+
+.marquee.small .foreground {
+    padding: var(--spacing-xl) 0;
+}
+
+.marquee.large {
+    display: block;
+}
+
+.marquee.large .foreground {
+    padding: var(--spacing-m) 0;
+    gap: 0;
+}
+
+.marquee.large .background img {
+    max-height: 259px;
+}
+
+.marquee.large .background picture {
+    position: relative;
+}
+
+.marquee.large.dark {
+    background-color: black;
+}
+
+.marquee.large .text {
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+}
+
+.marquee .text p {
+    margin: 0 0 var(--spacing-s);
+}
+
+.marquee .text p:last-of-type {
+    margin-bottom: 0;
+}
+
+.marquee .text .detail-M {
+    margin-bottom: var(--spacing-xs);
+}
+
+.marquee .text .detail-L,
+.marquee .text .heading-XL,
+.marquee .text .heading-XXL {
+    margin-bottom: var(--spacing-xs);
+}
+
+.marquee .text p.icon-area {
+    margin-bottom: var(--spacing-s);
+}
+
+.marquee .text .icon-area picture {
+    display: block;
+    line-height: 0;
+}
+
+.marquee .text .icon-area img {
+    height: 48px;
+    width: auto;
+    display: block;
+}
+
+.marquee.large .text .icon-area img {
+    height: 64px;
+}
+
+.marquee .action-area {
+    display: flex;
+    margin: 0;
+    gap: var(--spacing-s);
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.marquee.large p.action-area {
+    order: 2;
+    margin-bottom: var(--spacing-s);
+}
+
+.marquee.large .text .body-XL {
+    order: 3;
+}
+
+.marquee.large .text .supplemental-text {
+    order: 2;
+    margin-bottom: var(--spacing-s);
+    font-weight: 700;
+}
+
+.marquee .media {
+    order: 1;
+    width: var(--grid-container-width); /* 10 grid / 83% */
+    margin: 0 auto;
+}
+
+.marquee .media img,
+.marquee .media video {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.marquee .text,
+.marquee.large .text {
+    order: 2;
+}
+
+.marquee.small .text {
+    order: 1;
+}
+
+.marquee.small .media {
+    order: 2;
+}
+
+@media screen and (min-width: 600px) {
+
+    .marquee .background .mobileOnly,
+    .marquee .background .desktopOnly {
+        display: none;
+    }
+
+    .marquee .background .tabletOnly {
+        display: block;
+    }
+
+    /* Split */
+    .marquee.split.one-third {
+        display: block;
+    }
+
+    .marquee.split {
+        display: flex;
+        justify-content: center;
+    }
+
+    .marquee.split .foreground.container .text {
+        max-width: calc(50% - var(--grid-column-width));
+    }
+
+    .marquee.split.three-quarter .foreground.container .text {
+        max-width: calc(75% - var(--grid-column-width));
+    }
+
+    .marquee.split.one-third .foreground.container .text {
+        max-width: none;
+    }
+
+    .marquee.split.one-third.large .foreground.container .text {
+        max-width: none;
+    }
+
+    .marquee.split.three-quarter .media.bleed {
+        width: calc(var(--grid-container-width) * 0.25 + (100vw - var(--grid-container-width)) / 2);
+    }
+
+    .marquee.split.one-third .media.bleed {
+        position: static;
+        width: 100%;
+    }
+
+    .marquee.split .media.bleed {
+        position: absolute;
+        width: 50vw;
+        right: 0;
+        height: 100%;
+    }
+
+    .marquee.split .media.bleed picture,
+    .marquee.split .media.bleed video {
+        height: 100%;
+        object-fit: fill;
+    }
+
+    .marquee.split.large .text {
+        margin: 0;
+    }
+
+    .marquee.split.small .media img,
+    .marquee.split.large .media img,
+    .marquee.split .media img,
+    .marquee.split.small .media video,
+    .marquee.split.large .media video,
+    .marquee.split .media video {
+        max-height: initial;
+    }
+
+}
+
+@media screen and (min-width: 900px) {
+    .marquee.split.one-third {
+        display: flex;
+        justify-content: center;
+    }
+
+    .marquee.split.one-third .media.bleed {
+        position: absolute;
+        width: calc(var(--grid-container-width) * 0.6667 + (100vw - var(--grid-container-width)) / 2);
+        right: 0;
+        height: 100%;
+    }
+
+    .marquee.split.one-third .foreground.container .text,
+    .marquee.split.one-third.large .foreground.container .text {
+        max-width: calc(33.333% - var(--grid-column-width));
+    }
+
+}
+
+@media screen and (min-width: 1200px) {
+    .marquee {
+        min-height: 560px;
+    }
+
+    .marquee .background .mobileOnly.tabletOnly,
+    .marquee .background .mobileOnly,
+    .marquee .background .tabletOnly {
+        display: none;
+    }
+
+    .marquee .background .desktopOnly {
+        display: block;
+    }
+
+    .marquee .foreground {
+        flex-direction: row;
+        align-items: center;
+        padding: 0;
+        gap: 100px; /* 1 column */
+    }
+
+    .marquee .foreground .text {
+        max-width: 500px;
+    }
+
+    .marquee .foreground .media {
+        max-width: 600px;
+    }
+
+    .marquee.quiet.centered .foreground,
+    .marquee.inline.centered .foreground {
+        justify-content: center;
+    }
+
+    .marquee.quiet .foreground,
+    .marquee.inline .foreground,
+    .marquee.split .foreground {
+        justify-content: initial;
+    }
+
+    .marquee.small .foreground {
+        padding: 0;
+    }
+
+    .marquee .media img,
+    .marquee .media video {
+        width: 100%;
+        max-width: initial;
+        min-height: 150px;
+    }
+
+    .marquee .text {
+        padding: var(--spacing-xl) 0;
+    }
+
+    .marquee.small .text {
+        padding: var(--spacing-l) 0;
+    }
+
+    .marquee.split .text {
+        padding: var(--spacing-xxl) 0;
+    }
+
+    .marquee.split.small .text {
+        padding: var(--spacing-xl) 0;
+    }
+
+    .marquee .text,
+    .marquee.small .text,
+    .marquee.large .text {
+        order: unset;
+    }
+
+    .marquee.large {
+        min-height: 700px;
+        display: flex;
+    }
+
+    .marquee .media,
+    .marquee.small .media,
+    .marquee.large .media {
+        order: unset;
+    }
+
+    .marquee.large .background img {
+        max-height: unset;
+    }
+
+    .marquee.large .background picture {
+        position: absolute;
+    }
+
+    .marquee.large .text {
+        display: block;
+    }
+
+    .marquee.large .supplemental-text {
+        margin: var(--spacing-s) 0 0 0;
+    }
+
+    .marquee.split.large .heading-XXL {
+        margin-bottom: var(--spacing-xs);
+    }
+
+    .marquee.split.large p.action-area:last-of-type {
+        margin-bottom: 0;
+    }
+}
+
+@media screen and (min-width: 1440px) {
+    .marquee.large .foreground.container {
+        max-width: var(--grid-container-width);
+    }
+}

--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -1,3 +1,100 @@
+:root main .marquee {
+    --color-accent: rgb(20, 115, 230);
+    --color-accent-hover: rgb(13, 102, 208);
+    --link-color: #035fe6;
+}
+
+main .container {
+    width: var(--grid-container-width);
+    margin: 0 auto;
+}
+
+main .marquee a {
+    color: var(--link-color);
+    text-decoration: none;
+}
+
+main .marquee .con-button {
+    color: #FFF;
+    border: 2px solid;
+    background-color: transparent;
+    border-radius: 16px;
+    display: inline-block;
+    padding: 5px 14px;
+    text-decoration: none;
+    font-size: 14px;
+    line-height: 16px;
+    font-style: normal;
+    font-weight: 700;
+}
+
+main .marquee .con-button.button-L {
+    padding: 7px 18px 8px;
+    line-height: 20px;
+    border-radius: 20px;
+    font-size: 17px;
+    min-height: 21px;
+}
+
+main .marquee .con-button.button-XL {
+    padding: 10px 24px 8px;
+    line-height: 24px;
+    border-radius: 25px;
+    font-size: 19px;
+    min-height: 28px;
+}
+
+main .marquee .con-button.button-justified {
+    display: block;
+    text-align: center;
+    width: 100%;
+}
+
+main .marquee.light .con-button {
+    color: #000;
+}
+
+main .marquee .con-button.blue {
+    color: #FFF;
+    background: var(--color-accent);
+    border: 2px solid var(--color-accent);
+}
+
+main .marquee .con-button.blue:hover,
+.con-button.blue:active {
+    background: var(--color-accent-hover);
+    border-color: var(--color-accent-hover);
+}
+
+main .marquee .con-button.blue:hover {
+    text-decoration: none;
+}
+
+main .marquee .con-button.outline {
+    border: 2px solid #000;
+    color: #000;
+}
+
+main .marquee .con-button.outline:hover {
+    background-color: #000;
+    color: #fff;
+    text-decoration: none;
+}
+
+main .marquee.dark .con-button.outline {
+    border: 2px solid #fff;
+    color: #fff;
+}
+
+main .marquee.dark .con-button.outline:hover {
+    background-color: #fff;
+    color: #000;
+}
+
+main .dark a:any-link {
+    color: #FFF;
+}
+
 main .section-wrapper .marquee-wrapper {
     max-width: none;
     padding: 0;
@@ -24,15 +121,6 @@ main .section-wrapper .marquee-wrapper {
 
 .marquee.centered {
     text-align: center;
-}
-
-.marquee .foreground {
-    margin: 0 auto;
-}
-
-.marquee.centered .foreground,
-.marquee.centered .action-area {
-    justify-content: center;
 }
 
 .marquee .background.has-video {

--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -2,6 +2,7 @@
     --color-accent: rgb(20, 115, 230);
     --color-accent-hover: rgb(13, 102, 208);
     --link-color: #035fe6;
+    --grid-container-width: 83.4%;
 }
 
 main .container {
@@ -527,6 +528,10 @@ main .section-wrapper .marquee-wrapper {
 }
 
 @media screen and (min-width: 1440px) {
+    :root main .marquee {
+        --grid-container-width: 1200px;
+    }
+
     .marquee.large .foreground.container {
         max-width: var(--grid-container-width);
     }

--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -1,3 +1,8 @@
+main .section-wrapper .marquee-wrapper {
+    max-width: none;
+    padding: 0;
+}
+
 .marquee {
     position: relative;
     color: #FFF;
@@ -19,6 +24,10 @@
 
 .marquee.centered {
     text-align: center;
+}
+
+.marquee .foreground {
+    margin: 0 auto;
 }
 
 .marquee.centered .foreground,

--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+function decorateBlockAnalytics(blockEl) {
+  blockEl.setAttribute('daa-im', 'true');
+  blockEl.setAttribute('daa-lh', [...blockEl.classList].join('|'));
+}
+
+function decorateLinkAnalytics(textEl, headings) {
+  const headingText = [...headings].map((heading) => heading.textContent);
+  textEl.setAttribute('daa-lh', headingText.join('|'));
+  const links = textEl.querySelectorAll('a, button');
+  links.forEach((link, i) => {
+    let linkType = 'link';
+    const { classList } = link;
+    if (classList.contains('con-button') && classList.contains('blue')) { linkType = 'filled'; }
+    if (classList.contains('con-button') && classList.contains('outline')) { linkType = 'outline'; }
+    const str = `${linkType}|${link.innerText} ${i + 1}`;
+    link.setAttribute('daa-ll', str);
+  });
+}
+
+function decorateButtons(el, size) {
+  const buttons = el.querySelectorAll('em a, strong a');
+  if (buttons.length === 0) return;
+  buttons.forEach((button) => {
+    const parent = button.parentElement;
+    const buttonType = parent.nodeName === 'STRONG' ? 'blue' : 'outline';
+    button.classList.add('con-button', buttonType);
+    if (size) button.classList.add(size); /* button-L, button-XL */
+    parent.insertAdjacentElement('afterend', button);
+    parent.remove();
+  });
+  const actionArea = buttons[0].closest('p');
+  actionArea.classList.add('action-area');
+  actionArea.nextElementSibling?.classList.add('supplemental-text', 'body-XL');
+}
+
+function getBlockSize(el) {
+  const sizes = ['small', 'medium', 'large'];
+  return sizes.find((size) => el.classList.contains(size)) || sizes[1]; /* medium default */
+}
+
+const decorateVideo = (container) => {
+  const link = container.querySelector('a[href$=".mp4"]');
+
+  container.innerHTML = `<video preload="metadata" playsinline autoplay muted loop>
+    <source src="${link.href}" type="video/mp4" />
+  </video>`;
+  container.classList.add('has-video');
+};
+
+const decorateBlockBg = (block, node) => {
+  const viewports = ['mobileOnly', 'tabletOnly', 'desktopOnly'];
+  const childCount = node.childElementCount;
+  const { children } = node;
+
+  node.classList.add('background');
+
+  if (childCount === 2) {
+    children[0].classList.add(viewports[0], viewports[1]);
+    children[1].classList.add(viewports[2]);
+  }
+
+  Array.from(children).forEach((child, index) => {
+    if (childCount === 3) {
+      child.classList.add(viewports[index]);
+    }
+
+    if (child.querySelector('a[href$=".mp4"]')) {
+      decorateVideo(child);
+    }
+  });
+
+  if (!node.querySelector(':scope img') && !node.querySelector(':scope video')) {
+    block.style.background = node.textContent;
+    node.remove();
+  }
+};
+
+function decorateText(el, size) {
+  const headings = el.querySelectorAll('h1, h2, h3, h4, h5, h6');
+  const heading = headings[headings.length - 1];
+  const decorate = (headingEl, headingSize, bodySize, detailSize) => {
+    headingEl.classList.add(`heading-${headingSize}`);
+    headingEl.nextElementSibling?.classList.add(`body-${bodySize}`);
+    const sib = headingEl.previousElementSibling;
+    if (sib) {
+      // eslint-disable-next-line no-unused-expressions
+      sib.querySelector('img, .icon') ? sib.classList.add('icon-area') : sib.classList.add(`detail-${detailSize}`);
+      sib.previousElementSibling?.classList.add('icon-area');
+    }
+  };
+  // eslint-disable-next-line no-unused-expressions
+  size === 'large' ? decorate(heading, 'XXL', 'XL', 'L') : decorate(heading, 'XL', 'M', 'M');
+}
+
+function extendButtonsClass(text) {
+  const buttons = text.querySelectorAll('.con-button');
+  if (buttons.length === 0) return;
+  buttons.forEach((button) => { button.classList.add('button-justified-mobile'); });
+}
+
+export default function init(el) {
+  decorateBlockAnalytics(el);
+  const isLight = el.classList.contains('light');
+  if (!isLight) el.classList.add('dark');
+  const children = el.querySelectorAll(':scope > div');
+  const foreground = children[children.length - 1];
+  if (children.length > 1) {
+    children[0].classList.add('background');
+    decorateBlockBg(el, children[0]);
+  }
+  foreground.classList.add('foreground', 'container');
+  const headline = foreground.querySelector('h1, h2, h3, h4, h5, h6');
+  const text = headline.closest('div');
+  text.classList.add('text');
+  const media = foreground.querySelector(':scope > div:not([class])');
+  media?.classList.add('media');
+
+  if (media?.querySelector('a[href$=".mp4"]')) {
+    decorateVideo(media);
+  } else {
+    media?.classList.add('image');
+  }
+
+  const size = getBlockSize(el);
+  decorateButtons(text, size === 'large' ? 'button-XL' : 'button-L');
+  const headings = text.querySelectorAll('h1, h2, h3, h4, h5, h6');
+  decorateLinkAnalytics(text, headings);
+  decorateText(text, size);
+  extendButtonsClass(text);
+  if (el.classList.contains('split')) {
+    if (foreground && media) {
+      media.classList.add('bleed');
+      foreground.insertAdjacentElement('beforebegin', media);
+    }
+  }
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -34,6 +34,7 @@
   --color-info-accent-hover: #4646C6;
   --color-info-accent-down: #3D3DB4;
   --color-info-accent-light: #DEDEF9;
+  --text-color: #2c2c2c;
 
   /* body */
   --body-background-color: var(--color-white);
@@ -61,7 +62,7 @@
   --heading-font-size-m: 1.5rem; /* 24px */
   --heading-font-size-s: 1.25rem; /* 20px */
   --heading-font-size-xs: 1.125rem; /* 18px */
-  
+
   /* details */
   --detail-font-weight: 700;
   --detail-color: var(--color-gray-600);
@@ -79,6 +80,10 @@
   --spacing-l: 48px;
   --spacing-xl: 56px;
   --spacing-xxl: 80px;
+
+  /* grid sizes */
+  --grid-container-width: 83.4%;
+  --grid-column-width: calc(var(--grid-container-width) / 12);
 }
 
 
@@ -91,6 +96,12 @@
 @media (min-width: 1200px) {
   :root {
     --heading-font-size-xxxl: 2.75rem; /* 44px */
+  }
+}
+
+@media (max-width: 1440px) {
+  :root {
+    --grid-container-width: 1200px;
   }
 }
 
@@ -113,7 +124,7 @@ a.button:any-link {
   /* outline: none; (keep outline for a11n) */
   text-align: center;
   font-size: var(--body-font-size-s);
-  font-style: normal; 
+  font-style: normal;
   font-weight: 600;
   cursor: pointer;
   color: var(--color-white);
@@ -414,7 +425,7 @@ main .featured-article-container div h1 {
 }
 
 main .article-feed {
-  min-height: 900px;  
+  min-height: 900px;
 }
 
 body {


### PR DESCRIPTION
Migrating the Marquee block over from the Milo main website to Blog.

Milo Marquee demo:
https://milo.adobe.com/docs/library/blocks/marquee

Blog Marquee demo:
https://milo-marquee--blog--webistry-development.hlx.page/en/drafts/williambsm/marquee

There are font sizing differences, but Mat and I agree that until we completely switch to Milo, we should keep the sizing in line with the current Blog sizes.

I have also imported certain functions from the milo script.js and the milo styles.css in order to make this block compatible. If you feel like they should be properly moved to the blog styles.css and script.js let me know, but since this is temporary I felt like we should not pollute the actual blog code until we migrate.

Authoring document:
https://adobe.sharepoint.com/:w:/r/sites/TheBlog/Shared%20Documents/theblog/en/drafts/williambsm/marquee.docx?d=w1154394e4e684c8f8c5e971845fbe721&csf=1&web=1&e=Po0wa8