### PR TITLE
chore: push down header when sidekick opens

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,6 +1,7 @@
 {
   "project": "Adobe Blog",
   "host": "blog.adobe.com",
+  "pushDownSelector": "header",
   "plugins": [
     {
       "id": "tagger",


### PR DESCRIPTION
When push down is enabled in the sidekick, the `header` remains covered by the sidekick due to its absolute positioning.

To test, enable push down under Options > User Experience and head to

https://main--blog--adobe.hlx.page/

Now change the repository URL to `https://github.com/adobe/blog/tree/sk-push-down-header` under Options > Projects > Blog, then head to:

https://sk-push-down-header--blog--adobe.hlx.page/