### PR TITLE
Requested changes to the Sticky Header block

### DIFF
--- a/blocks/sticky-header/close.svg
+++ b/blocks/sticky-header/close.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>

--- a/blocks/sticky-header/close.svg
+++ b/blocks/sticky-header/close.svg
@@ -1,1 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+<svg id="Icon" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12">
+  <rect id="Frame" width="12" height="12" fill="black" opacity="0"/>
+  <path id="Path_72" data-name="Path 72" d="M7.4,6,11.33,2.068a.989.989,0,1,0-1.4-1.4L6,4.6,2.068.67a.989.989,0,1,0-1.4,1.4L4.6,6,.67,9.932a.989.989,0,1,0,1.4,1.4L6,7.4,9.932,11.33a.989.989,0,1,0,1.4-1.4Z" fill="black"/>
+</svg>

--- a/blocks/sticky-header/sticky-header.css
+++ b/blocks/sticky-header/sticky-header.css
@@ -28,3 +28,7 @@
     font-size: 14px;
     user-select: none;
 }
+
+.sticky-header-close {
+  cursor: pointer;
+}

--- a/blocks/sticky-header/sticky-header.css
+++ b/blocks/sticky-header/sticky-header.css
@@ -21,6 +21,48 @@
     display: block;
 }
 
+@-webkit-keyframes buttonGradient {
+    0% {
+        background-position: 0% 50%
+    }
+
+    50% {
+        background-position: 100% 50%
+    }
+
+    100% {
+        background-position: 0% 50%
+    }
+}
+
+@-moz-keyframes buttonGradient {
+    0% {
+        background-position: 0% 50%
+    }
+
+    50% {
+        background-position: 100% 50%
+    }
+
+    100% {
+        background-position: 0% 50%
+    }
+}
+
+@keyframes buttonGradient {
+    0% {
+        background-position: 0% 50%
+    }
+
+    50% {
+        background-position: 100% 50%
+    }
+
+    100% {
+        background-position: 0% 50%
+    }
+}
+
 .block.sticky-header .button {
     display: block;
     margin: 0;
@@ -30,6 +72,9 @@
     background: linear-gradient(320deg, #7C84F3, #FF4DD2, #FF993B, #FF4DD2, #7C84F3, #FF4DD2, #FF993B);
     background-size: 400% 400%;
     background-position: center;
+    -webkit-animation: buttonGradient 45s ease infinite;
+    -moz-animation: buttonGradient 45s ease infinite;
+    animation: buttonGradient 45s ease infinite;
 }
 
 .sticky-header-close {

--- a/blocks/sticky-header/sticky-header.css
+++ b/blocks/sticky-header/sticky-header.css
@@ -27,11 +27,9 @@
     font-weight: normal;
     font-size: 14px;
     user-select: none;
-    background-color: #FF0000;
-}
-
-.block.sticky-header .button:hover {
-  background-color: #ec0000;
+    background: linear-gradient(320deg, #7C84F3, #FF4DD2, #FF993B, #FF4DD2, #7C84F3, #FF4DD2, #FF993B);
+    background-size: 400% 400%;
+    background-position: center;
 }
 
 .sticky-header-close {

--- a/blocks/sticky-header/sticky-header.css
+++ b/blocks/sticky-header/sticky-header.css
@@ -27,6 +27,11 @@
     font-weight: normal;
     font-size: 14px;
     user-select: none;
+    background-color: #FF0000;
+}
+
+.block.sticky-header .button:hover {
+  background-color: #ec0000;
 }
 
 .sticky-header-close {

--- a/blocks/sticky-header/sticky-header.js
+++ b/blocks/sticky-header/sticky-header.js
@@ -2,23 +2,20 @@ import { createTag } from '../block-helpers.js';
 
 export default function decorate($block) {
   const $header = document.querySelector('header');
-  const $stickyHeader = document.querySelector('.sticky-header.block')
-  const $stickyHeaderContents = document.querySelector('.sticky-header div')
-
-  $header.parentNode.insertBefore($block, $header.nextSibling);
-
+  const $div = $block.firstChild;
   const $a = $block.querySelector('a');
-  $a.classList.add('button');
-  $a.target = '_blank';
-
-  // Should these go at the top?
   const $close = createTag('a', { class: 'sticky-header-close' });
   const $closeIcon = createTag('img', { class: 'sticky-header-close-icon', src: '/blocks/sticky-header/close.svg' });
 
-  $close.addEventListener('click', (e) => {
-    $stickyHeader.remove()
-  })
+  $header.parentNode.insertBefore($block, $header.nextSibling);
 
-  $stickyHeaderContents.append($close)
-  $close.append($closeIcon)
+  $a.classList.add('button');
+  $a.target = '_blank';
+
+  $close.addEventListener('click', () => {
+    $block.remove();
+  });
+
+  $div.append($close);
+  $close.append($closeIcon);
 }

--- a/blocks/sticky-header/sticky-header.js
+++ b/blocks/sticky-header/sticky-header.js
@@ -4,4 +4,5 @@ export default function decorate($block) {
 
   const $a = $block.querySelector('a');
   $a.classList.add('button');
+  $a.setAttribute('target', '_blank')
 }

--- a/blocks/sticky-header/sticky-header.js
+++ b/blocks/sticky-header/sticky-header.js
@@ -13,7 +13,7 @@ export default function decorate($block) {
 
   // Should these go at the top?
   const $close = createTag('a', { class: 'sticky-header-close' });
-  const $closeIcon = createTag('img', { class: 'newsletter-modal-close-icon', src: '/blocks/sticky-header/close.svg' });
+  const $closeIcon = createTag('img', { class: 'sticky-header-close-icon', src: '/blocks/sticky-header/close.svg' });
 
   $close.addEventListener('click', (e) => {
     $stickyHeader.remove()

--- a/blocks/sticky-header/sticky-header.js
+++ b/blocks/sticky-header/sticky-header.js
@@ -4,5 +4,5 @@ export default function decorate($block) {
 
   const $a = $block.querySelector('a');
   $a.classList.add('button');
-  $a.setAttribute('target', '_blank')
+  $a.target = '_blank';
 }

--- a/blocks/sticky-header/sticky-header.js
+++ b/blocks/sticky-header/sticky-header.js
@@ -1,8 +1,24 @@
+import { createTag } from '../block-helpers.js';
+
 export default function decorate($block) {
   const $header = document.querySelector('header');
+  const $stickyHeader = document.querySelector('.sticky-header.block')
+  const $stickyHeaderContents = document.querySelector('.sticky-header div')
+
   $header.parentNode.insertBefore($block, $header.nextSibling);
 
   const $a = $block.querySelector('a');
   $a.classList.add('button');
   $a.target = '_blank';
+
+  // Should these go at the top?
+  const $close = createTag('a', { class: 'sticky-header-close' });
+  const $closeIcon = createTag('img', { class: 'newsletter-modal-close-icon', src: '/blocks/sticky-header/close.svg' });
+
+  $close.addEventListener('click', (e) => {
+    $stickyHeader.remove()
+  })
+
+  $stickyHeaderContents.append($close)
+  $close.append($closeIcon)
 }


### PR DESCRIPTION
Minor list of changes:
- The button is now red
- There is now a close button with the block
- The button should now open in a new tab

Before URL:
https://main--blog--adobe.hlx.page/en/drafts/thomas/sticky-header

After URL:
https://header-open-links--blog--webistry-development.hlx.page/en/drafts/thomas/sticky-header