### PR TITLE
fix(topics): Fix incompatibility issue with Marquee block

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -702,13 +702,19 @@ function buildArticleHeader(mainEl) {
 
 function buildTagHeader(mainEl) {
   const div = mainEl.querySelector('div');
-  const heading = mainEl.querySelector('h1, h2');
-  const picture = mainEl.querySelector('picture');
-  const tagHeaderBlockEl = buildBlock('tag-header', [
-    [heading],
-    [{ elems: [picture.closest('p')] }],
-  ]);
-  div.prepend(tagHeaderBlockEl);
+
+  if (div) {
+    const heading = div.querySelector('h1, h2');
+    const picture = div.querySelector('picture');
+
+    if (picture) {
+      const tagHeaderBlockEl = buildBlock('tag-header', [
+        [heading],
+        [{ elems: [picture.closest('p')] }],
+      ]);
+      div.prepend(tagHeaderBlockEl);
+    }
+  }
 }
 
 function buildAuthorHeader(mainEl) {


### PR DESCRIPTION
The way the logic for the Topics pages work is that it would look for any image at all in the original main element on page load, and use it to set it up as a background ([Exibit A](https://main--blog--adobe.hlx.page/en/topics/diverse-voices)). When not using images, it would cause the page to break and align the header in a way that is appropriate ([Exibit B](https://main--blog--adobe.hlx.page/en/topics/digital-transformation)).

The issue with this is that once you are using a block like the Marquee block, the page tries to hijack the Marquee image in order to do its thing ([Exhibit C](https://main--blog--adobe.hlx.page/en/topics/sundance)).

I've built a fix that will allow it to do all of the following three without actually breaking anything in the code.

See Exhibit A, B and C when the fix is in place:
https://topics-fix--blog--webistry-development.hlx.page/en/topics/diverse-voices
https://topics-fix--blog--webistry-development.hlx.page/en/topics/digital-transformation
https://topics-fix--blog--webistry-development.hlx.page/en/topics/sundance

