### PR TITLE
Allow the Marquee block to co-operate with legacy layout

### DIFF
--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -10,6 +10,10 @@ main .container {
     margin: 0 auto;
 }
 
+main .marquee {
+    margin: 0 -2rem;
+}
+
 main .marquee a {
     color: var(--link-color);
     text-decoration: none;
@@ -94,11 +98,6 @@ main .marquee.dark .con-button.outline:hover {
 
 main .dark a:any-link {
     color: #FFF;
-}
-
-main .section-wrapper .marquee-wrapper {
-    max-width: none;
-    padding: 0;
 }
 
 .marquee {
@@ -324,6 +323,14 @@ main .section-wrapper .marquee-wrapper {
 }
 
 @media screen and (min-width: 600px) {
+    main .section-wrapper .marquee-wrapper {
+        max-width: none;
+        padding: 0;
+    }
+
+    main .marquee {
+        margin: initial;
+    }
 
     .marquee .background .mobileOnly,
     .marquee .background .desktopOnly {


### PR DESCRIPTION
This Pull Request is in response to https://jira.corp.adobe.com/browse/MWPW-126156

The solution presented here is a bit unconventional, but allows for the current Milo Marquee block to co-operate with the legacy structure of the current Milo website.

**Test URLs (without the marquee)**
- Before: https://main--blog--adobe.hlx.page/en/drafts/williambsm/marquee-mobile-fix/page-without-marquee
- After: https://marquee-mobile-fix--blog--webistry-development.hlx.page/en/drafts/williambsm/marquee-mobile-fix/page-without-marquee

**Test URLs (with the marquee)**
- Before: https://main--blog--adobe.hlx.page/en/drafts/williambsm/marquee-mobile-fix/page-with-marquee
- After:  https://marquee-mobile-fix--blog--webistry-development.hlx.page/en/drafts/williambsm/marquee-mobile-fix/page-with-marquee