### PR TITLE
feat(tabs): import the latest tab version from adobecom/milo

### DIFF
--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -23,6 +23,15 @@ main .tabs .section-wrapper:first-of-type {
     margin-top: 0;
 }
 
+.tabs .section-wrapper > div {
+    max-width: 800px;
+}
+
+.tabs-wrapper {
+    max-width: none!important;
+    padding: 0!important;
+}
+
 .tabs {
     position: relative;
     margin: 0;

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -126,22 +126,22 @@ main .tabs .section-wrapper:first-of-type {
     border-bottom: 1px solid var(--tabs-border-color);
 }
 
-.tabContent [role='tabpanel'] .section {
+.tabContent [role='tabpanel'] .section-wrapper {
     position: relative;
 }
 
-.tabContent [role='tabpanel'] .section picture.section-background {
+.tabContent [role='tabpanel'] .section-wrapper picture.section-background {
     z-index: 0;
 }
 
-.tabContent [role='tabpanel'] .section > .content {
+.tabContent [role='tabpanel'] .section-wrapper > div {
     z-index: 1;
     position: relative;
 }
 
 /* contained tabs content */
 .tabs.contained .tabContent .tabContent-container,
-[role='tabpanel'] > .section > .content {
+[role='tabpanel'] > .section-wrapper > div {
     width: var(--grid-container-width);
     margin: 0 auto;
 }

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -8,7 +8,6 @@
     --tabs-bg-color: #f1f1f1;
     --tabs-active-bg-color: #ffffff;
     --tabs-list-bg-gradient: linear-gradient(rgba(255,255,255,0) 60%, rgba(245,245,245,.8));
-    --grid-container-width: 83.4%;
 }
 
 :root .dark {
@@ -20,23 +19,15 @@
     --tabs-list-bg-gradient: linear-gradient(rgba(0,0,0,0) 60%, rgba(0,0,0,.8));
 }
 
+main .tabs .section-wrapper:first-of-type {
+    margin-top: 0;
+}
+
 .tabs {
     position: relative;
     margin: 0;
     color: var(--tabs-active-text-color);
-}
-
-.tabs .section-wrapper > div {
-    max-width: 800px;
-}
-
-.tabs-wrapper {
-    max-width: none!important;
-    padding: 0!important;
-}
-
-.tabs .section-wrapper:first-of-type {
-    margin-top: 0;
+    background-color: var(--tabs-active-bg-color);
 }
 
 .tabs.xxl-spacing {
@@ -122,16 +113,28 @@
 }
 
 .tabs .tabContent {
-    padding: 0;
-    border-bottom: 1px solid var(--tabs-border-color)
+    padding: var(--spacing-s) 0;
+    border-bottom: 1px solid var(--tabs-border-color);
+}
+
+.tabContent [role='tabpanel'] .section {
+    position: relative;
+}
+
+.tabContent [role='tabpanel'] .section picture.section-background {
+    z-index: 0;
+}
+
+.tabContent [role='tabpanel'] .section > .content {
+    z-index: 1;
+    position: relative;
 }
 
 /* contained tabs content */
 .tabs.contained .tabContent .tabContent-container,
-[role='tabpanel'] > .section-wrapper > div {
+[role='tabpanel'] > .section > .content {
     width: var(--grid-container-width);
     margin: 0 auto;
-    overflow: auto;
 }
 
 .tabs div[role="tablist"] button {

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -5,7 +5,7 @@
 import { createTag } from '../block-helpers.js';
 
 function getStringKeyName(str) {
-  return str.trim().replaceAll(' ', '-').toLowerCase();
+  return str.trim().replaceAll(/[^a-zA-Z0-9 ]/g, '').replaceAll(' ', '-').toLowerCase();
 }
 
 const isElementInContainerView = (targetEl) => {

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -135,7 +135,8 @@ export default function decorate(block) {
   configRows.splice(0, 1);
   if (configRows) {
     configRows.forEach((row) => {
-      const rowKey = getStringKeyName(row.children[0].textContent);
+      let rowKey = getStringKeyName(row.children[0].textContent);
+      if (rowKey === 'activetab') rowKey = 'active-tab';
       config[rowKey] = row.children[1].textContent.trim();
       row.remove();
     });


### PR DESCRIPTION
This is a two part Pull Request that is importing the latest milo tabs block, and aims to allow special characters to be used in the naming of tabs. in response to a request made by Kristina to fix this bug. 

**In an example document:**
Before: https://main--blog--adobe.hlx.page/en/drafts/williambsm/tabs-syntax-fix/tabs-demo
After: https://tabs-fix--blog--webistry-development.hlx.page/en/drafts/williambsm/tabs-syntax-fix/tabs-demo

**In a currently live page:**
Before: https://main--blog--adobe.hlx.page/en/topics/celebrating-the-black-community
After: https://tabs-fix--blog--webistry-development.hlx.page/en/topics/celebrating-the-black-community

There is a minor spacing change at the top of the tab content, but I believe it comes from the newest version of the tabs block and it actually looks better than the original, so I haven't tried to re-style it.