### PR TITLE
chore: shift mobile breakpoint from 400px to 600px

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1054,7 +1054,7 @@ export function normalizeHeadings(el, allowedHeadings) {
  * @param {Array} breakpoints breakpoints and corresponding params (eg. width)
  */
 
-export function createOptimizedPicture(src, alt = '', eager = false, breakpoints = [{ media: '(min-width: 400px)', width: '2000' }, { width: '750' }]) {
+export function createOptimizedPicture(src, alt = '', eager = false, breakpoints = [{ media: '(min-width: 600px)', width: '2000' }, { width: '750' }]) {
   const url = new URL(src, window.location.href);
   const picture = document.createElement('picture');
   const { pathname } = url;


### PR DESCRIPTION
https://mobile-breakpoint--blog--adobe.hlx.page/?hlx-pipeline-version=ci4162
vs
https://main--blog--adobe.hlx.page/